### PR TITLE
Use PyMODINIT_FUNC for module init functions

### DIFF
--- a/greenlet.c
+++ b/greenlet.c
@@ -1265,12 +1265,13 @@ static struct PyModuleDef greenlet_module_def = {
 	GreenMethods,
 };
 
-PyObject *
+PyMODINIT_FUNC
 PyInit_greenlet(void)
 #else
 #define INITERROR return
 
-void initgreenlet(void)
+PyMODINIT_FUNC
+initgreenlet(void)
 #endif
 {
 	PyObject* m = NULL;

--- a/tests/_test_extension.c
+++ b/tests/_test_extension.c
@@ -168,7 +168,7 @@ static struct PyModuleDef moduledef = {
 	NULL
 };
 
-PyObject *
+PyMODINIT_FUNC
 PyInit__test_extension(void)
 #else
 #define INITERROR return


### PR DESCRIPTION
I noticed there was a change for compiling greenlet code by g++, and well, in order for greenlet to successfully compile as C++ (e.g. by renaming greenlet.c to greenlet.cpp) you also need to use PyMODINIT_FUNC for correct signature.
