### PR TITLE
Add ppc64 platform

### DIFF
--- a/platform/switch_ppc64_linux.h
+++ b/platform/switch_ppc64_linux.h
@@ -1,0 +1,70 @@
+/*
+ * this is the internal transfer function.
+ *
+ * HISTORY
+ * 09-Mar-12 Michael Ellerman <michael@ellerman.id.au>
+ *      64-bit implementation, copied from 32-bit.
+ * 07-Sep-05 (py-dev mailing list discussion)
+ *      removed 'r31' from the register-saved.  !!!! WARNING !!!!
+ *      It means that this file can no longer be compiled statically!
+ *      It is now only suitable as part of a dynamic library!
+ * 14-Jan-04  Bob Ippolito <bob@redivi.com>
+ *      added cr2-cr4 to the registers to be saved.
+ *      Open questions: Should we save FP registers?
+ *      What about vector registers?
+ *      Differences between darwin and unix?
+ * 24-Nov-02  Christian Tismer  <tismer@tismer.com>
+ *      needed to add another magic constant to insure
+ *      that f in slp_eval_frame(PyFrameObject *f)
+ *      STACK_REFPLUS will probably be 1 in most cases.
+ *      gets included into the saved stack area.
+ * 04-Oct-02  Gustavo Niemeyer <niemeyer@conectiva.com>
+ *      Ported from MacOS version.
+ * 17-Sep-02  Christian Tismer  <tismer@tismer.com>
+ *      after virtualizing stack save/restore, the
+ *      stack size shrunk a bit. Needed to introduce
+ *      an adjustment STACK_MAGIC per platform.
+ * 15-Sep-02  Gerd Woetzel       <gerd.woetzel@GMD.DE>
+ *      slightly changed framework for sparc
+ * 29-Jun-02  Christian Tismer  <tismer@tismer.com>
+ *      Added register 13-29, 31 saves. The same way as
+ *      Armin Rigo did for the x86_unix version.
+ *      This seems to be now fully functional!
+ * 04-Mar-02  Hye-Shik Chang  <perky@fallin.lv>
+ *      Ported from i386.
+ */
+
+#define STACK_REFPLUS 1
+
+#ifdef SLP_EVAL
+
+#define STACK_MAGIC 6
+
+/* !!!!WARNING!!!! need to add "r31" in the next line if this header file
+ * is meant to be compiled non-dynamically!
+ */
+#define REGS_TO_SAVE "r2", "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
+       "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29", "r31", \
+       "cr2", "cr3", "cr4"
+static int
+slp_switch(void)
+{
+    register long *stackref, stsizediff;
+    __asm__ volatile ("" : : : REGS_TO_SAVE);
+    __asm__ ("mr %0, 1" : "=g" (stackref) : );
+    {
+        SLP_SAVE_STATE(stackref, stsizediff);
+        __asm__ volatile (
+            "mr 11, %0\n"
+            "add 1, 1, 11\n"
+            : /* no outputs */
+            : "g" (stsizediff)
+            : "11"
+            );
+        SLP_RESTORE_STATE();
+    }
+    __asm__ volatile ("" : : : REGS_TO_SAVE);
+    return 0;
+}
+
+#endif

--- a/slp_platformselect.h
+++ b/slp_platformselect.h
@@ -10,6 +10,8 @@
 #include "platform/switch_amd64_unix.h" /* gcc on amd64 */
 #elif defined(__GNUC__) && defined(__i386__)
 #include "platform/switch_x86_unix.h" /* gcc on X86 */
+#elif defined(__GNUC__) && defined(__powerpc64__) && defined(__linux__)
+#include "platform/switch_ppc64_linux.h" /* gcc on PowerPC 64-bit */
 #elif defined(__GNUC__) && defined(__PPC__) && defined(__linux__)
 #include "platform/switch_ppc_linux.h" /* gcc on PowerPC */
 #elif defined(__GNUC__) && defined(__ppc__) && defined(__APPLE__)


### PR DESCRIPTION
Add 64-bit ppc support with a new platform file and update to the
platformselect code.

Signed-off-by: Michael Ellerman michael@ellerman.id.au
Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
