### PR TITLE
Removed include of sys/trap.h and defined ST_FLUSH_WINDOWS to be 3

### DIFF
--- a/platform/switch_sparc_sun_gcc.h
+++ b/platform/switch_sparc_sun_gcc.h
@@ -26,9 +26,9 @@
 
 #ifdef SLP_EVAL
 
-#include <sys/trap.h>
 
 #define STACK_MAGIC 0
+#define ST_FLUSH_WINDOWS 3
 
 static int
 slp_switch(void)


### PR DESCRIPTION
The second and final modified file for the support for Debian Sparc
