### PR TITLE
fix compilation of greenlet for Linux on PowerPC

### DIFF
--- a/platform/switch_ppc64_linux.h
+++ b/platform/switch_ppc64_linux.h
@@ -32,6 +32,8 @@
  *      This seems to be now fully functional!
  * 04-Mar-02  Hye-Shik Chang  <perky@fallin.lv>
  *      Ported from i386.
+ * 31-Jul-12  Trevor Bowen    <trevorbowen@gmail.com>
+ *      Changed memory constraints to register only.
  */
 
 #define STACK_REFPLUS 1
@@ -51,14 +53,14 @@ slp_switch(void)
 {
     register long *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
-    __asm__ ("mr %0, 1" : "=g" (stackref) : );
+    __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
         __asm__ volatile (
             "mr 11, %0\n"
             "add 1, 1, 11\n"
             : /* no outputs */
-            : "g" (stsizediff)
+            : "r" (stsizediff)
             : "11"
             );
         SLP_RESTORE_STATE();

--- a/platform/switch_ppc_linux.h
+++ b/platform/switch_ppc_linux.h
@@ -30,6 +30,8 @@
  *      This seems to be now fully functional!
  * 04-Mar-02  Hye-Shik Chang  <perky@fallin.lv>
  *      Ported from i386.
+ * 31-Jul-12  Trevor Bowen    <trevorbowen@gmail.com>
+ *      Changed memory constraints to register only.
  */
 
 #define STACK_REFPLUS 1
@@ -49,7 +51,7 @@ slp_switch(void)
 {
     register int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
-    __asm__ ("mr %0, 1" : "=g" (stackref) : );
+    __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
         __asm__ volatile (
@@ -57,7 +59,7 @@ slp_switch(void)
             "add 1, 1, 11\n"
             "add 30, 30, 11\n"
             : /* no outputs */
-            : "g" (stsizediff)
+            : "r" (stsizediff)
             : "11"
             );
         SLP_RESTORE_STATE();


### PR DESCRIPTION
Per #16, commit f61a3b06fdc52b7401d39d9aa1708924c2565490 applies a small patch to restrict assembly macro to only use registers instead of potentially also using stack space, which violates PPC's MR opcode requirements.  The current fix is for PPC and PPC64 on Linux only.  This change may also be helpful on UNIX, AIX, and MacOS platforms, but I do not have them available for testing.

Incidentally, the problem occurs for me with cross-compiler, gcc-4.3.74-eglibc-2.8.74-dp-2 and default optimization flags.  Forcing level-2 optimization, `-O2`, also works around the problem, but it seems riskier than refining the memory space requirement, hence this patch.
