### PR TITLE
Fix for TypeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,8 @@ class build_ext(_build_ext):
         compiler = self.compiler
         if compiler.__class__.__name__ != "UnixCCompiler":
             return
-        import ipdb; ipdb.set_trace()
-        compiler.compiler_so += ["-fno-tree-dominator-opts"]
+
+        compiler.compiler_so += "-fno-tree-dominator-opts"
         tmpdir = tempfile.mkdtemp()
 
         try:


### PR DESCRIPTION
Hello,

I was getting a TypeError trying to install greenlet on Python 2.7.5 on OS X 10.8.4 and Homebrew.

https://gist.github.com/shurik/6096212

So I changed the list to a string and it seems to work Ok.
