### PR TITLE
Fix aliasing issues with GCC 4.8.0 and Python 2.x

### DIFF
--- a/greenlet.c
+++ b/greenlet.c
@@ -106,6 +106,10 @@ The running greenlet's stack_start is undefined but not NULL.
 #ifndef Py_TYPE
 #  define Py_TYPE(ob)   (((PyObject *) (ob))->ob_type)
 #endif
+#ifndef PyVarObject_HEAD_INIT
+#  define PyVarObject_HEAD_INIT(type, size) \
+    PyObject_HEAD_INIT(type) size,
+#endif
 #endif
 
 #if PY_VERSION_HEX < 0x02050000
@@ -1450,12 +1454,7 @@ static PyNumberMethods green_as_number = {
 
 
 PyTypeObject PyGreenlet_Type = {
-#if PY_MAJOR_VERSION >= 3
 	PyVarObject_HEAD_INIT(NULL, 0)
-#else
-	PyObject_HEAD_INIT(NULL)
-	0,					/* ob_size */
-#endif
 	"greenlet.greenlet",			/* tp_name */
 	sizeof(PyGreenlet),			/* tp_basicsize */
 	0,					/* tp_itemsize */

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import sys, os, glob, platform, tempfile, shutil
+import sys, os, glob, platform
 
 # workaround segfaults on openbsd and RHEL 3 / CentOS 3 . see
 # https://bitbucket.org/ambroff/greenlet/issue/11/segfault-on-openbsd-i386
@@ -54,32 +54,9 @@ else:
         extra_objects=extra_objects,
         depends=['greenlet.h', 'slp_platformselect.h'] + _find_platform_headers())]
 
-from my_build_ext import build_ext as _build_ext
+from my_build_ext import build_ext
+
 from distutils.core import Command
-
-
-class build_ext(_build_ext):
-    def configure_compiler(self):
-        compiler = self.compiler
-        if compiler.__class__.__name__ != "UnixCCompiler":
-            return
-
-        compiler.compiler_so += ["-fno-tree-dominator-opts"]
-        tmpdir = tempfile.mkdtemp()
-
-        try:
-            simple_c = os.path.join(tmpdir, "simple.c")
-            open(simple_c, "w").write("void foo(){}")
-            compiler.compile([simple_c], output_dir=tmpdir)
-        except Exception:
-            del compiler.compiler_so[-1]
-
-        shutil.rmtree(tmpdir)
-
-    def build_extensions(self):
-        self.configure_compiler()
-        _build_ext.build_extensions(self)
-
 
 class fixup(Command):
     user_options = []


### PR DESCRIPTION
Reverting the previous attempts at fixing the miscompiles
with GCC 4.8 and switch to the -fstrict-aliasing save variant
that works also on ARMv7 (where the previous workaround failed).

See http://www.python.org/dev/peps/pep-3123/ for the explanation
and the inspiration for the fix.
