### PR TITLE
setup.py: Use setuptools for bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ try:
             or "upload" in sys.argv
             or "fixup" in sys.argv
             or "bdist_egg" in sys.argv
+            or "bdist_wheel" in sys.argv
             or "test" in sys.argv):
         raise ImportError()
     from setuptools import setup, Extension


### PR DESCRIPTION
Solves this problem:

```
(responsesvc)marca@marca-mac2:~/dev/git-repos/greenlet$ python setup.py bdist_wheel
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: invalid command 'bdist_wheel'
```
