### PR TITLE
Allow building for x86 Linux on GCC < 4.5

### DIFF
--- a/platform/switch_x86_unix.h
+++ b/platform/switch_x86_unix.h
@@ -36,9 +36,15 @@
 /* the above works fine with gcc 2.96, but 2.95.3 wants this */
 #define STACK_MAGIC 0
 
+#if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5)
+# define ATTR_NOCLONE __attribute__((noclone))
+#else
+# define ATTR_NOCLONE
+#endif
+
 /* See below for the purpose of this function.  */
-__attribute__((noinline, noclone)) int fancy_return_zero(void);
-__attribute__((noinline, noclone)) int
+__attribute__((noinline)) ATTR_NOCLONE int fancy_return_zero(void);
+__attribute__((noinline)) ATTR_NOCLONE int
 fancy_return_zero(void)
 {
   return 0;


### PR DESCRIPTION
The noclone attribute is introduced in GCC 4.5, this patch allows building with older GCC versions (again). This may or may not reintroduce the segfaults that 5a0a628021357bf37cccbcc401e07dc99e9415ee speaks of, unfortunately I cannot get any segfaults with that commit's parent (nor does it describe a testcase), so I cannot verify the absence of introducing this particular segfault.

I can however confirm that after running a server with it (gevent on top of greenlet) I have had plenty of uncaught Python exceptions but not a single segfault (since early November).
