### PR TITLE
Sparc: use the FLUSHW instruction when available

### DIFF
--- a/platform/switch_sparc_sun_gcc.h
+++ b/platform/switch_sparc_sun_gcc.h
@@ -55,7 +55,11 @@ slp_switch(void)
      *
      * Then put the stack pointer into stackref. */
     __asm__ volatile (
+#ifdef __sparcv9
+        "flushw\n\t"
+#else
         "ta %1\n\t"
+#endif
         "mov %%sp, %0"
         : "=r" (stackref) :  "i" (ST_FLUSH_WINDOWS));
 


### PR DESCRIPTION
This instruction tends to have better performance than

```
ta ST_FLUSHWINDOWS
```

It isn't available on all systems though, hence the conditional.
