### PR TITLE
updating default compiler options for MacOS X

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,12 @@ class build_ext(_build_ext):
         if compiler.__class__.__name__ != "UnixCCompiler":
             return
 
-        compiler.compiler_so += ["-fno-tree-dominator-opts"]
+        if sys.platform == 'darwin':
+            if '-mno-fused-madd' in compiler.compiler_so:
+                compiler.compiler_so.remove('-mno-fused-madd')
+        else:
+            compiler.compiler_so += ["-fno-tree-dominator-opts"]
+
         tmpdir = tempfile.mkdtemp()
 
         try:


### PR DESCRIPTION
Xcode 5.1 changed the acceptable compiler flags, fully deprecating
-mno-fused-madd. This update works around the default compiler_so
options provided from distutils

resolves https://github.com/python-greenlet/greenlet/issues/46
