### PR TITLE
Re-code the saving of the gp register for MIPS64 so it compiles

### DIFF
--- a/platform/switch_mips_unix.h
+++ b/platform/switch_mips_unix.h
@@ -18,7 +18,13 @@ static int
 slp_switch(void)
 {
     register int *stackref, stsizediff;
+#ifdef __mips64
+    uint64_t gpsave;
+#endif
     __asm__ __volatile__ ("" : : : REGS_TO_SAVE);
+#ifdef __mips64
+    __asm__ __volatile__ ("sd $28,%0" : "=m" (gpsave) : : );
+#endif
     __asm__ ("move %0, $29" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
@@ -33,6 +39,9 @@ slp_switch(void)
             );
         SLP_RESTORE_STATE();
     }
+#ifdef __mips64
+    __asm__ __volatile__ ("ld $28,%0" : : "m" (gpsave) : );
+#endif
     __asm__ __volatile__ ("" : : : REGS_TO_SAVE);
     return 0;
 }


### PR DESCRIPTION
In working on a project that wants to use greenlet on a MIPS64-based Linux system, I ran into the following compilation error:

```
In file included from slp_platformselect.h:36:0,
                  from greenlet.c:416:
platform/switch_mips_unix.h: In function 'slp_switch':
platform/switch_mips_unix.h:26:5: error: PIC register clobbered by '$28' in 'asm'
     __asm__ __volatile__ ("" : : : REGS_TO_SAVE);
     ^
platform/switch_mips_unix.h:41:5: error: PIC register clobbered by '$28' in 'asm'
     __asm__ __volatile__ ("" : : : REGS_TO_SAVE);
     ^
```

This was using gcc 4.7 and 4.9.  To fix this, I came up with this alternative way of saving the gp register.  The generated assembly looks correct, and all tests are passing.
