### PR TITLE
arm32: make sure gcc uses a frame pointer

### DIFF
--- a/platform/switch_arm32_gcc.h
+++ b/platform/switch_arm32_gcc.h
@@ -50,6 +50,9 @@
 #endif
 
 static int
+#ifdef __GNUC__
+__attribute__((optimize("no-omit-frame-pointer")))
+#endif
 slp_switch(void)
 {
         void *fp;


### PR DESCRIPTION
This code assumes that there is a frame pointer. When gcc doesn't use a
frame pointer here and `__thumb__` is defined, then the code clobbers r7
without declaring it to the compiler. If the compiler uses r7 for
something else, then this causes arbitrary failures, depending on what
the optimizer did.

To work around this, tell gcc to always use a frame pointer.
- Example compiler output before this change: https://gist.github.com/basak/b0d2580887259a7996a3
- Example compiler output after this change: https://gist.github.com/basak/85b88e6df4f7da8215c1

This fixes one of two issues with test failures when building with gcc gcc 4.9.1 (-5ubuntu1) on Ubuntu Utopic.
