### PR TITLE
Fixes nit in method green_setrun's argument name

### DIFF
--- a/greenlet.c
+++ b/greenlet.c
@@ -834,7 +834,7 @@ static PyObject* green_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 	return o;
 }
 
-static int green_setrun(PyGreenlet* self, PyObject* nparent, void* c);
+static int green_setrun(PyGreenlet* self, PyObject* nrun, void* c);
 static int green_setparent(PyGreenlet* self, PyObject* nparent, void* c);
 
 static int green_init(PyGreenlet *self, PyObject *args, PyObject *kwargs)


### PR DESCRIPTION
There seems a copy-paste error in method green_setrun declaration,
This commit keeps it same with its defination.