### PR TITLE
Revert "Sparc: use the FLUSHW instruction when available"

### DIFF
--- a/platform/switch_sparc_sun_gcc.h
+++ b/platform/switch_sparc_sun_gcc.h
@@ -55,11 +55,7 @@ slp_switch(void)
      *
      * Then put the stack pointer into stackref. */
     __asm__ volatile (
-#ifdef __sparcv9
-        "flushw\n\t"
-#else
         "ta %1\n\t"
-#endif
         "mov %%sp, %0"
         : "=r" (stackref) :  "i" (ST_FLUSH_WINDOWS));
 


### PR DESCRIPTION
We have a scenario in which Python crashes with segmentation fault after calling green_switch on solaris-11-sparc

We do not understand exactly where the memory overrun occurs, but without this commit our tests pass, and with it Python crashes.

This reverts commit 76711b1276698c0af2bc62fbb5a8c2d762696fda.