### PR TITLE
Fix #82 by doing what the ctypes module does.

### DIFF
--- a/greenlet.c
+++ b/greenlet.c
@@ -90,6 +90,10 @@ The running greenlet's stack_start is undefined but not NULL.
 #endif
 #endif
 
+#if PY_VERSION_HEX < 0x02060000
+#define PyLong_FromSsize_t PyInt_FromLong
+#endif
+
 #if PY_VERSION_HEX < 0x02050000
 typedef int Py_ssize_t;
 #endif


### PR DESCRIPTION
Specifically, defining PyLong_FromSsize_t PyInt_FromLongSsize_t to be PyInt_FromLong on Python 2.5.

I haven't tested this, I don't have any systems around with python2.5 (I was seeing this problem on TravisCI).