### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,4 +54,4 @@ The source code repository is hosted on github:
 https://github.com/python-greenlet/greenlet
 
 Documentation is available on readthedocs.org:
-https://greenlet.readthedocs.org
+https://greenlet.readthedocs.io


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.