### PR TITLE
Use x instead of r for aarch64 register names

### DIFF
--- a/platform/switch_aarch64_gcc.h
+++ b/platform/switch_aarch64_gcc.h
@@ -2,6 +2,7 @@
  * this is the internal transfer function.
  *
  * HISTORY
+ * 07-Sep-16 Add clang support using x register naming. Fredrik Fornwall
  * 13-Apr-13 Add support for strange GCC caller-save decisions
  * 08-Apr-13 File creation. Michael Matz
  *
@@ -15,8 +16,8 @@
 
 #ifdef SLP_EVAL
 #define STACK_MAGIC 0
-#define REGS_TO_SAVE "r19", "r20", "r21", "r22", "r23", "r24", "r25", "r26", \
-                     "r27", "r28", "r30" /* aka lr */, \
+#define REGS_TO_SAVE "x19", "x20", "x21", "x22", "x23", "x24", "x25", "x26", \
+                     "x27", "x28", "x30" /* aka lr */, \
                      "v8", "v9", "v10", "v11", \
                      "v12", "v13", "v14", "v15"
 


### PR DESCRIPTION
This fixes clang compatibility (tested with clang 3.9).

I'm not that into inline assembly (so please review), but as noticed in https://github.com/termux/termux-packages/issues/438 using `r19` does not seem to work with clang on `aarch64`, while `x19` does.

As I understand it this should also work on gcc. From https://wiki.cdot.senecacollege.ca/wiki/Aarch64_Register_and_Instruction_Quick_Start, the naming of aarch64 registers are:

- r0 through r30 - to refer generally to the registers
- x0 through x30 - for 64-bit-wide access (same registers)
- w0 through w30 - for 32-bit-wide access (same registers - upper 32 bits are either cleared on load or sign-extended (set to the value of the most significant bit of the loaded value)).
