### PR TITLE
Don't clobber 'r2' register on ppc64el

### DIFF
--- a/platform/switch_ppc64_linux.h
+++ b/platform/switch_ppc64_linux.h
@@ -56,7 +56,7 @@
 #define ALTIVEC_REGS
 #endif
 
-#define REGS_TO_SAVE "r2", "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
+#define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
        "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29", "r31", \
        "fr14", "fr15", "fr16", "fr17", "fr18", "fr19", "fr20", "fr21", \
        "fr22", "fr23", "fr24", "fr25", "fr26", "fr27", "fr28", "fr29", \


### PR DESCRIPTION
It was invalid even before, now GCC 7 no longer accept this.

Fixes this build failure:
powerpc64le-linux-gnu-gcc -pthread -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC -I/usr/include/python3.6m -c greenlet.c -o build/temp.linux-ppc64le-3.6/greenlet.o -fno-tree-dominator-opts
In file included from slp_platformselect.h:16:0,
                 from greenlet.c:328:
platform/switch_ppc64_linux.h: In function 'slp_switch':
platform/switch_ppc64_linux.h:72:5: error: PIC register clobbered by 'r2' in 'asm'
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     ^~~~~~~
platform/switch_ppc64_linux.h:85:5: error: PIC register clobbered by 'r2' in 'asm'
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     ^~~~~~~
error: command 'powerpc64le-linux-gnu-gcc' failed with exit status 1