### PR TITLE
Add MINGW64 support on MSYS2 platform

### DIFF
--- a/platform/switch_amd64_unix.h
+++ b/platform/switch_amd64_unix.h
@@ -44,7 +44,11 @@ slp_switch(void)
     void* rbx;
     unsigned int csr;
     unsigned short cw;
+#ifdef __MINGW64__
+    register long long *stackref, stsizediff;
+#else
     register long *stackref, stsizediff;
+#endif
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ volatile ("fstcw %0" : "=m" (cw));
     __asm__ volatile ("stmxcsr %0" : "=m" (csr));

--- a/setup.py
+++ b/setup.py
@@ -43,14 +43,14 @@ if hasattr(sys, "pypy_version_info"):
 else:
     headers = ['greenlet.h']
 
-    if sys.platform == 'win32' and '64 bit' in sys.version:
+    if sys.platform == 'win32' and '64 bit' in sys.version and not 'GCC' in sys.version:
         # this works when building with msvc, not with 64 bit gcc
         # switch_x64_masm.obj can be created with setup_switch_x64_masm.cmd
         extra_objects = ['platform/switch_x64_masm.obj']
     else:
         extra_objects = []
 
-    if sys.platform == 'win32' and os.environ.get('GREENLET_STATIC_RUNTIME') in ('1', 'yes'):
+    if sys.platform == 'win32' and os.environ.get('GREENLET_STATIC_RUNTIME') in ('1', 'yes') and not 'GCC' in sys.version:
         extra_compile_args = ['/MT']
     elif hasattr(os, 'uname') and os.uname()[4] in ['ppc64el', 'ppc64le']:
         extra_compile_args = ['-fno-tree-dominator-opts']


### PR DESCRIPTION
It seems we can not build with `x86_64-w64-mingw32-gcc.exe` on MSYS2 due
to the fact that

- `sizeof(long)` is different on general UNIX and MINGW64, 8 and 4,
respectively.
- Assumption on MSVC compiler if `sys.platform` is win32 in setup.py.

Using `long long` instead of `long` and handling GCC cases on win32
platforms seem to be enough for MINGW64 support without breaking
anything.

Credit goes to http://proglab.blog.fc2.com/blog-entry-48.html and Google
Translate.