### PR TITLE
Fix wrong platform inclusion for mingw64

### DIFF
--- a/platform/switch_x64_msvc.h
+++ b/platform/switch_x64_msvc.h
@@ -22,7 +22,10 @@
  *      Initial final version after lots of iterations for i386.
  */
 
+/* Avoid alloca redefined warning on mingw64 */
+#ifndef alloca
 #define alloca _alloca
+#endif
 
 #define STACK_REFPLUS 1
 #define STACK_MAGIC 0

--- a/slp_platformselect.h
+++ b/slp_platformselect.h
@@ -4,7 +4,7 @@
 
 #if   defined(MS_WIN32) && !defined(MS_WIN64) && defined(_M_IX86) && defined(_MSC_VER)
 #include "platform/switch_x86_msvc.h" /* MS Visual Studio on X86 */
-#elif defined(MS_WIN64) && defined(_M_X64) && defined(_MSC_VER)
+#elif defined(MS_WIN64) && defined(_M_X64) && defined(_MSC_VER) || defined(__MINGW64__)
 #include "platform/switch_x64_msvc.h" /* MS Visual Studio on X64 */
 #elif defined(__GNUC__) && defined(__amd64__) && defined(__ILP32__)
 #include "platform/switch_x32_unix.h" /* gcc on amd64 with x32 ABI */


### PR DESCRIPTION
While building with mingw64, `platform/switch_amd64_unix.h` is included,
which causes a build error. This commit ensures
`platform/switch_x64_msvc.h` is included instead. This time it gives a
warning about redefinition of `alloca` at this file and its previous
definition at `malloc.h`. `#ifdef alloca` is added to avoid this
warning.

When I build with these changes I can `pip3 install neovim` and my python-based neovim plugins work.