### PR TITLE
platform/switch_*: remove duplicate code.

### DIFF
--- a/platform/switch_aarch64_gcc.h
+++ b/platform/switch_aarch64_gcc.h
@@ -62,7 +62,6 @@ slp_switch(void)
            __asm__ volatile ("mov %0, #0" : "=r" (err));
         }
         __asm__ volatile ("ldr x29, %0" : : "m" (fp) :);
-        __asm__ volatile ("" : : : REGS_TO_SAVE);
         return err;
 }
 

--- a/platform/switch_arm32_gcc.h
+++ b/platform/switch_arm32_gcc.h
@@ -72,7 +72,6 @@ slp_switch(void)
                 SLP_RESTORE_STATE();
         }
         __asm__ volatile ("ldr r0,%1\n\tmov " REG_FP ",r0\n\tmov %0, #0" : "=r" (result) : "m" (fp) : "r0");
-        __asm__ volatile ("" : : : REGS_TO_SAVE);
         return result;
 }
 

--- a/platform/switch_m68k_gcc.h
+++ b/platform/switch_m68k_gcc.h
@@ -31,7 +31,6 @@ slp_switch(void)
   }
   __asm__ volatile ("move.l %0, %%a5" : : "m"(a5));
   __asm__ volatile ("move.l %0, %%fp" : : "m"(fp));
-  __asm__ volatile ("" : : : REGS_TO_SAVE);
   return err;
 }
 

--- a/platform/switch_mips_unix.h
+++ b/platform/switch_mips_unix.h
@@ -45,7 +45,6 @@ slp_switch(void)
 #ifdef __mips64
     __asm__ __volatile__ ("ld $28,%0" : : "m" (gpsave) : );
 #endif
-    __asm__ __volatile__ ("" : : : REGS_TO_SAVE);
     __asm__ __volatile__ ("move %0, $0" : "=r" (err));
     return err;
 }

--- a/platform/switch_ppc_linux.h
+++ b/platform/switch_ppc_linux.h
@@ -65,7 +65,6 @@ slp_switch(void)
             );
         SLP_RESTORE_STATE();
     }
-    __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ volatile ("li %0, 0" : "=r" (err));
     return err;
 }

--- a/platform/switch_x86_unix.h
+++ b/platform/switch_x86_unix.h
@@ -87,7 +87,6 @@ slp_switch(void)
     __asm__ volatile ("movl %0, %%ebx" : : "m" (ebx));
     __asm__ volatile ("movl %0, %%ebp" : : "m" (ebp));
     __asm__ volatile ("fldcw %0" : : "m" (cw));
-    __asm__ volatile ("" : : : "esi", "edi");
     return err;
 }
 


### PR DESCRIPTION
Seems "asm volatile("":::REGS_TO_SAVE)" only need once in the slp_switch().

Because one REGS_TO_SAVE will let gcc to insert "push&pop the preserve-regs" at
slp_switch() begin&end.

Signed-off-by: Guo Ren <ren_guo@c-sky.com>