### PR TITLE
Fix issue #119

### DIFF
--- a/platform/switch_ppc64_linux.h
+++ b/platform/switch_ppc64_linux.h
@@ -2,6 +2,10 @@
  * this is the internal transfer function.
  *
  * HISTORY
+ * 21-Mar-18  Tulio Magno Quites Machado Filho  <tuliom@linux.vnet.ibm.com>
+ *      Added r30 to the list of saved registers in order to fully comply with
+ *      both ppc64 ELFv1 ABI and the ppc64le ELVv2 ABI, that classify this
+ *      register as a nonvolatile register used for local variables.
  * 21-Mar-18  Laszlo Boszormenyi  <gcs@debian.org>
  *      Save r2 (TOC pointer) manually.
  * 10-Dec-13  Ulrich Weigand  <uweigand@de.ibm.com>
@@ -58,8 +62,9 @@
 #define ALTIVEC_REGS
 #endif
 
-#define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
-       "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29", "r31", \
+#define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20",  \
+       "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29",  \
+       "r30","r31",                                                    \
        "fr14", "fr15", "fr16", "fr17", "fr18", "fr19", "fr20", "fr21", \
        "fr22", "fr23", "fr24", "fr25", "fr26", "fr27", "fr28", "fr29", \
        "fr30", "fr31", \

--- a/platform/switch_ppc64_linux.h
+++ b/platform/switch_ppc64_linux.h
@@ -2,6 +2,8 @@
  * this is the internal transfer function.
  *
  * HISTORY
+ * 21-Mar-18  Laszlo Boszormenyi  <gcs@debian.org>
+ *      Save r2 (TOC pointer) manually.
  * 10-Dec-13  Ulrich Weigand  <uweigand@de.ibm.com>
  *	Support ELFv2 ABI.  Save float/vector registers.
  * 09-Mar-12 Michael Ellerman <michael@ellerman.id.au>
@@ -56,7 +58,7 @@
 #define ALTIVEC_REGS
 #endif
 
-#define REGS_TO_SAVE "r2", "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
+#define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20", \
        "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29", "r31", \
        "fr14", "fr15", "fr16", "fr17", "fr18", "fr19", "fr20", "fr21", \
        "fr22", "fr23", "fr24", "fr25", "fr26", "fr27", "fr28", "fr29", \
@@ -69,7 +71,9 @@ slp_switch(void)
 {
     register int err;
     register long *stackref, stsizediff;
+    void * toc;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
+    __asm__ volatile ("std 2, %0" : "=m" (toc));
     __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
@@ -82,6 +86,7 @@ slp_switch(void)
             );
         SLP_RESTORE_STATE();
     }
+    __asm__ volatile ("ld 2, %0" : : "m" (toc));
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ volatile ("li %0, 0" : "=r" (err));
     return err;


### PR DESCRIPTION
This patch set implements the requests from PR #120 and fixes issue #119:

- r2 is saved and restored manually.
- Added a ChangeLog to the file.
- Added r30 to the list of registers to save.