### PR TITLE
Update switch_ppc_aix.h

### DIFF
--- a/platform/switch_ppc_aix.h
+++ b/platform/switch_ppc_aix.h
@@ -56,14 +56,14 @@ slp_switch(void)
     register int err;
     register int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
-    __asm__ ("mr %0, 1" : "=g" (stackref) : );
+    __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
         __asm__ volatile (
             "mr 11, %0\n"
             "add 1, 1, 11\n"
             : /* no outputs */
-            : "g" (stsizediff)
+            : "r" (stsizediff)
             : "11"
             );
         SLP_RESTORE_STATE();


### PR DESCRIPTION
Based off abarnert's feedback on stackoverflow, force use of a register instead of a hint.  

From:
https://stackoverflow.com/questions/11587635/cross-compile-of-pythons-greenlet-and-gevent-on-linux-x86-64-for-powerpc