### PR TITLE
Add python 3.8 to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7-dev
+  - 3.7
+  - 3.8
 
 install: python setup.py build_ext -i
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,7 @@ language: python
 sudo: false
 
 python:
-  - 2.6
   - 2.7
-  - 3.2
-  - 3.3
   - 3.4
   - 3.5
   - 3.6


### PR DESCRIPTION
Also 3.7 is available, no need to use 3.7-dev

First step in addressing #151 

Because they are no longer supported in travis, dropped the tests in python 2.6, 3.2 and 3.3