### PR TITLE
Add old environments to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,21 @@ sudo: false
 matrix:
   include:
   - arch: arm64
+    python: 2.6
+  - arch: amd64
+    python: 2.6
+  - arch: arm64
     python: 2.7
   - arch: amd64
     python: 2.7
+  - arch: arm64
+    python: 3.2
+  - arch: amd64
+    python: 3.2
+  - arch: arm64
+    python: 3.3
+  - arch: amd64
+    python: 3.3
   - arch: arm64
     python: 3.4
   - arch: amd64


### PR DESCRIPTION
This might just fix failing builds like this one:

https://travis-ci.org/python-greenlet/greenlet/builds/646537216