### PR TITLE
Fix build on FreeBSD/powerpc

### DIFF
--- a/slp_platformselect.h
+++ b/slp_platformselect.h
@@ -14,7 +14,7 @@
 #include "platform/switch_x86_unix.h" /* gcc on X86 */
 #elif defined(__GNUC__) && defined(__powerpc64__) && (defined(__linux__) || defined(__FreeBSD__))
 #include "platform/switch_ppc64_linux.h" /* gcc on PowerPC 64-bit */
-#elif defined(__GNUC__) && defined(__PPC__) && defined(__linux__)
+#elif defined(__GNUC__) && defined(__PPC__) && (defined(__linux__) || defined(__FreeBSD__))
 #include "platform/switch_ppc_linux.h" /* gcc on PowerPC */
 #elif defined(__GNUC__) && defined(__ppc__) && defined(__APPLE__)
 #include "platform/switch_ppc_macosx.h" /* Apple MacOS X on PowerPC */


### PR DESCRIPTION
FreeBSD/powerpc can use the same code as Linux/powerpc.
It passes all tests:
```
root@powerpc-121-default:/usr/ports/devel/py-greenlet # make test
===>  Testing for py37-greenlet-0.4.15
===>   py37-greenlet-0.4.15 depends on file: /usr/local/bin/python3.7 - found
running build_ext
Linking /wrkdirs/usr/ports/devel/py-greenlet/work-py37/greenlet-0.4.15/build/lib.freebsd-12.1-RELEASE-powerpc-3.7/greenlet.so to /wrkdirs/usr/ports/devel/py-greenlet/work-py37/greenlet-0.4.15/greenlet.so
python 3.7.7 (32 bit) using greenlet 0.4.15 from /wrkdirs/usr/ports/devel/py-greenlet/work-py37/greenlet-0.4.15/greenlet.so
test_abstract_subclasses (tests.test_greenlet.GreenletTests) ... ok
test_dealloc (tests.test_greenlet.GreenletTests) ... ok
test_dealloc_other_thread (tests.test_greenlet.GreenletTests) ... ok
test_dealloc_switch_args_not_lost (tests.test_greenlet.GreenletTests) ... ok
test_deepcopy (tests.test_greenlet.GreenletTests) ... ok
test_exc_state (tests.test_greenlet.GreenletTests) ... ok
test_exception (tests.test_greenlet.GreenletTests) ... ok
test_frame (tests.test_greenlet.GreenletTests) ... ok
test_implicit_parent_with_threads (tests.test_greenlet.GreenletTests) ... ok
test_instance_dict (tests.test_greenlet.GreenletTests) ... ok
test_parent_equals_None (tests.test_greenlet.GreenletTests) ... ok
test_parent_restored_on_kill (tests.test_greenlet.GreenletTests) ... ok
test_parent_return_failure (tests.test_greenlet.GreenletTests) ... ok
test_recursive_startup (tests.test_greenlet.GreenletTests) ... ok
test_run_equals_None (tests.test_greenlet.GreenletTests) ... ok
test_send_exception (tests.test_greenlet.GreenletTests) ... ok
test_simple (tests.test_greenlet.GreenletTests) ... ok
test_switch_kwargs (tests.test_greenlet.GreenletTests) ... ok
test_switch_kwargs_to_parent (tests.test_greenlet.GreenletTests) ... ok
test_switch_to_another_thread (tests.test_greenlet.GreenletTests) ... ok
test_thread_bug (tests.test_greenlet.GreenletTests) ... ok
test_threaded_reparent (tests.test_greenlet.GreenletTests) ... ok
test_threaded_updatecurrent (tests.test_greenlet.GreenletTests) ... ok
test_threads (tests.test_greenlet.GreenletTests) ... ok
test_throw_doesnt_crash (tests.test_greenlet.GreenletTests) ... ok
test_throw_exception_not_lost (tests.test_greenlet.GreenletTests) ... ok
test_two_children (tests.test_greenlet.GreenletTests) ... ok
test_two_recursive_children (tests.test_greenlet.GreenletTests) ... ok
test_unexpected_reparenting (tests.test_greenlet.GreenletTests) ... ok
test_circular_greenlet (tests.test_gc.GCTests) ... ok
test_dead_circular_ref (tests.test_gc.GCTests) ... ok
test_finalizer_crash (tests.test_gc.GCTests) ... ok
test_inactive_ref (tests.test_gc.GCTests) ... ok
test_generator (tests.test_generator.GeneratorTests) ... ok
test_getcurrent (tests.test_extension_interface.CAPITests) ... ok
test_new_greenlet (tests.test_extension_interface.CAPITests) ... ok
test_raise_greenlet_dead (tests.test_extension_interface.CAPITests) ... ok
test_raise_greenlet_error (tests.test_extension_interface.CAPITests) ... ok
test_setparent (tests.test_extension_interface.CAPITests) ... ok
test_switch (tests.test_extension_interface.CAPITests) ... ok
test_switch_kwargs (tests.test_extension_interface.CAPITests) ... ok
test_throw (tests.test_extension_interface.CAPITests) ... ok
test_stack_saved (tests.test_stack_saved.Test) ... ok
test_exception_switch (tests.test_cpp.CPPTests) ... ok
test_class (tests.test_throw.ThrowTests) ... ok
test_kill (tests.test_throw.ThrowTests) ... ok
test_throw_goes_to_original_parent (tests.test_throw.ThrowTests) ... ok
test_val (tests.test_throw.ThrowTests) ... ok
test_dead_weakref (tests.test_weakref.WeakRefTests) ... ok
test_dealloc_weakref (tests.test_weakref.WeakRefTests) ... ok
test_inactive_weakref (tests.test_weakref.WeakRefTests) ... ok
test_arg_refs (tests.test_leaks.ArgRefcountTests) ... ok
test_kwarg_refs (tests.test_leaks.ArgRefcountTests) ... ok
test_threaded_adv_leak (tests.test_leaks.ArgRefcountTests) ... ok
test_threaded_leak (tests.test_leaks.ArgRefcountTests) ... ok
test_genlet_bad (tests.test_generator_nested.NestedGeneratorTests) ... ok
test_genlet_simple (tests.test_generator_nested.NestedGeneratorTests) ... ok
test_layered_genlets (tests.test_generator_nested.NestedGeneratorTests) ... ok
test_nested_genlets (tests.test_generator_nested.NestedGeneratorTests) ... ok
test_permutations (tests.test_generator_nested.NestedGeneratorTests) ... ok
test_exception_disables_tracing (tests.test_tracing.TracingTests) ... ok
test_greenlet_tracing (tests.test_tracing.TracingTests) ... ok
test_version (tests.test_version.VersionTests) ... ok

----------------------------------------------------------------------
Ran 63 tests in 4.974s

OK
```