### PR TITLE
Provide support for PEP 567 ContextVars

### DIFF
--- a/greenlet.c
+++ b/greenlet.c
@@ -1760,6 +1760,7 @@ initgreenlet(void)
 	PyModule_AddObject(m, "GreenletExit", PyExc_GreenletExit);
 	PyModule_AddObject(m, "GREENLET_USE_GC", PyBool_FromLong(GREENLET_USE_GC));
 	PyModule_AddObject(m, "GREENLET_USE_TRACING", PyBool_FromLong(GREENLET_USE_TRACING));
+	PyModule_AddObject(m, "GREENLET_USE_CONTEXT_VARS", PyBool_FromLong(GREENLET_USE_CONTEXT_VARS));
 
 	/* also publish module-level data as attributes of the greentype. */
 	for (p=copy_on_greentype; *p; p++) {

--- a/greenlet.c
+++ b/greenlet.c
@@ -491,7 +491,9 @@ static int g_switchstack(void)
 		PyThreadState* tstate = PyThreadState_GET();
 		current->recursion_depth = tstate->recursion_depth;
 		current->top_frame = tstate->frame;
+#if GREENLET_USE_CONTEXT_VARS
 		current->context = tstate->context;
+#endif
 #ifdef GREENLET_USE_EXC_INFO
 		current->exc_info = tstate->exc_info;
 		current->exc_state = tstate->exc_state;
@@ -524,11 +526,13 @@ static int g_switchstack(void)
 		tstate->frame = target->top_frame;
 		target->top_frame = NULL;
 
+#if GREENLET_USE_CONTEXT_VARS
 		tstate->context = target->context;
 		target->context = NULL;
 		/* Incrementing this value invalidates the contextvars cache,
 		   which would otherwise remain valid across switches */
 		tstate->context_ver++;
+#endif
 
 #ifdef GREENLET_USE_EXC_INFO
 		tstate->exc_state = target->exc_state;
@@ -971,7 +975,9 @@ green_traverse(PyGreenlet *self, visitproc visit, void *arg)
 	   - frames are not visited: alive greenlets are not garbage collected anyway */
 	Py_VISIT((PyObject*)self->parent);
 	Py_VISIT(self->run_info);
+#if GREENLET_USE_CONTEXT_VARS
 	Py_VISIT(self->context);
+#endif
 #ifdef GREENLET_USE_EXC_INFO
 	Py_VISIT(self->exc_state.exc_type);
 	Py_VISIT(self->exc_state.exc_value);
@@ -1004,7 +1010,9 @@ static int green_clear(PyGreenlet* self)
 	   so even if it switches we are relatively safe. */
 	Py_CLEAR(self->parent);
 	Py_CLEAR(self->run_info);
+#if GREENLET_USE_CONTEXT_VARS
 	Py_CLEAR(self->context);
+#endif
 #ifdef GREENLET_USE_EXC_INFO
 	Py_CLEAR(self->exc_state.exc_type);
 	Py_CLEAR(self->exc_state.exc_value);
@@ -1083,7 +1091,9 @@ static void green_dealloc(PyGreenlet* self)
 		PyObject_ClearWeakRefs((PyObject *) self);
 	Py_CLEAR(self->parent);
 	Py_CLEAR(self->run_info);
+#if GREENLET_USE_CONTEXT_VARS
 	Py_CLEAR(self->context);
+#endif
 #ifdef GREENLET_USE_EXC_INFO
 	Py_CLEAR(self->exc_state.exc_type);
 	Py_CLEAR(self->exc_state.exc_value);

--- a/greenlet.h
+++ b/greenlet.h
@@ -29,6 +29,7 @@ typedef struct _greenlet {
 	struct _frame* top_frame;
 	int recursion_depth;
 	PyObject* weakreflist;
+	PyObject* context;
 #ifdef GREENLET_USE_EXC_INFO
 	_PyErr_StackItem* exc_info;
 	_PyErr_StackItem exc_state;

--- a/greenlet.h
+++ b/greenlet.h
@@ -37,9 +37,6 @@ typedef struct _greenlet {
 	struct _frame* top_frame;
 	int recursion_depth;
 	PyObject* weakreflist;
-#if GREENLET_USE_CONTEXT_VARS
-	PyObject* context;
-#endif
 #ifdef GREENLET_USE_EXC_INFO
 	_PyErr_StackItem* exc_info;
 	_PyErr_StackItem exc_state;
@@ -49,6 +46,9 @@ typedef struct _greenlet {
 	PyObject* exc_traceback;
 #endif
 	PyObject* dict;
+#if GREENLET_USE_CONTEXT_VARS
+	PyObject* context;
+#endif
 } PyGreenlet;
 
 #define PyGreenlet_Check(op)      PyObject_TypeCheck(op, &PyGreenlet_Type)

--- a/greenlet.h
+++ b/greenlet.h
@@ -17,6 +17,14 @@ extern "C" {
 #  define GREENLET_USE_EXC_INFO
 #endif
 
+#ifndef GREENLET_USE_CONTEXT_VARS
+#ifdef Py_CONTEXT_H
+#define GREENLET_USE_CONTEXT_VARS 1
+#else
+#define GREENLET_USE_CONTEXT_VARS 0
+#endif
+#endif
+
 typedef struct _greenlet {
 	PyObject_HEAD
 	char* stack_start;
@@ -29,7 +37,9 @@ typedef struct _greenlet {
 	struct _frame* top_frame;
 	int recursion_depth;
 	PyObject* weakreflist;
+#if GREENLET_USE_CONTEXT_VARS
 	PyObject* context;
+#endif
 #ifdef GREENLET_USE_EXC_INFO
 	_PyErr_StackItem* exc_info;
 	_PyErr_StackItem exc_state;

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -2,61 +2,59 @@ from functools import partial
 import greenlet
 import unittest
 
-SKIP_TESTS = False
+RUN_TESTS = True
 try:
     from contextvars import ContextVar
     from contextvars import copy_context
 except ImportError:
-    SKIP_TESTS = True
+    RUN_TESTS = False
 
+if RUN_TESTS:
+    class ContextVarsTests(unittest.TestCase):
+        def _new_ctx_run(self, *args, **kwargs):
+            return copy_context().run(*args, **kwargs)
 
-class ContextVarsTests(unittest.TestCase):
-    def _new_ctx_run(self, *args, **kwargs):
-        return copy_context().run(*args, **kwargs)
+        def _increment(self, greenlet_id, ctx_var, callback, counts, expect):
+            if expect is None:
+                self.assertIsNone(ctx_var.get())
+            else:
+                self.assertEqual(ctx_var.get(), expect)
+            ctx_var.set(greenlet_id)
+            for i in range(2):
+                counts[ctx_var.get()] += 1
+                callback()
 
-    def _increment(self, greenlet_id, ctx_var, callback, counts, expect):
-        if expect is None:
-            self.assertIsNone(ctx_var.get())
-        else:
-            self.assertEqual(ctx_var.get(), expect)
-        ctx_var.set(greenlet_id)
-        for i in range(2):
-            counts[ctx_var.get()] += 1
-            callback()
+        def _test_context(self, propagate):
+            id_var = ContextVar("id", default=None)
+            id_var.set(0)
 
-    def _test_context(self, propagate):
-        id_var = ContextVar("id", default=None)
-        id_var.set(0)
+            callback = greenlet.getcurrent().switch
+            counts = dict((i, 0) for i in range(5))
 
-        callback = greenlet.getcurrent().switch
-        counts = dict((i, 0) for i in range(5))
+            lets = [
+                greenlet.greenlet(partial(
+                    partial(
+                        copy_context().run,
+                        self._increment
+                    ) if propagate else self._increment,
+                    greenlet_id=i,
+                    ctx_var=id_var,
+                    callback=callback,
+                    counts=counts,
+                    expect=0 if propagate else None,
+                ))
+                for i in range(1, 5)
+            ]
 
-        lets = [
-            greenlet.greenlet(partial(
-                partial(
-                    copy_context().run,
-                    self._increment
-                ) if propagate else self._increment,
-                greenlet_id=i,
-                ctx_var=id_var,
-                callback=callback,
-                counts=counts,
-                expect=0 if propagate else None,
-            ))
-            for i in range(1, 5)
-        ]
+            for i in range(2):
+                counts[id_var.get()] += 1
+                for let in lets:
+                    let.switch()
 
-        for i in range(2):
-            counts[id_var.get()] += 1
-            for let in lets:
-                let.switch()
+            self.assertEqual(set(counts.values()), set([2]))
 
-        self.assertEqual(set(counts.values()), {2})
+        def test_context_propagated(self):
+            self._new_ctx_run(self._test_context, True)
 
-    @unittest.skipIf(SKIP_TESTS, "python runtime doesn't support contextvars")
-    def test_context_propagated(self):
-        self._new_ctx_run(self._test_context, True)
-
-    @unittest.skipIf(SKIP_TESTS, "python runtime doesn't support contextvars")
-    def test_context_not_propagated(self):
-        self._new_ctx_run(self._test_context, False)
+        def test_context_not_propagated(self):
+            self._new_ctx_run(self._test_context, False)

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -2,8 +2,12 @@ from functools import partial
 import greenlet
 import unittest
 
-from contextvars import ContextVar
-from contextvars import copy_context
+SKIP_TESTS = False
+try:
+    from contextvars import ContextVar
+    from contextvars import copy_context
+except ImportError:
+    SKIP_TESTS = True
 
 
 class ContextVarsTests(unittest.TestCase):
@@ -49,8 +53,10 @@ class ContextVarsTests(unittest.TestCase):
 
         self.assertEqual(set(counts.values()), {2})
 
+    @unittest.skipIf(SKIP_TESTS, "python runtime doesn't support contextvars")
     def test_context_propagated(self):
         self._new_ctx_run(self._test_context, True)
 
+    @unittest.skipIf(SKIP_TESTS, "python runtime doesn't support contextvars")
     def test_context_not_propagated(self):
         self._new_ctx_run(self._test_context, False)

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -2,14 +2,10 @@ from functools import partial
 import greenlet
 import unittest
 
-RUN_TESTS = True
-try:
+if greenlet.GREENLET_USE_CONTEXT_VARS:
     from contextvars import ContextVar
     from contextvars import copy_context
-except ImportError:
-    RUN_TESTS = False
 
-if RUN_TESTS:
     class ContextVarsTests(unittest.TestCase):
         def _new_ctx_run(self, *args, **kwargs):
             return copy_context().run(*args, **kwargs)

--- a/tests/test_contextvars.py
+++ b/tests/test_contextvars.py
@@ -1,0 +1,56 @@
+from functools import partial
+import greenlet
+import unittest
+
+from contextvars import ContextVar
+from contextvars import copy_context
+
+
+class ContextVarsTests(unittest.TestCase):
+    def _new_ctx_run(self, *args, **kwargs):
+        return copy_context().run(*args, **kwargs)
+
+    def _increment(self, greenlet_id, ctx_var, callback, counts, expect):
+        if expect is None:
+            self.assertIsNone(ctx_var.get())
+        else:
+            self.assertEqual(ctx_var.get(), expect)
+        ctx_var.set(greenlet_id)
+        for i in range(2):
+            counts[ctx_var.get()] += 1
+            callback()
+
+    def _test_context(self, propagate):
+        id_var = ContextVar("id", default=None)
+        id_var.set(0)
+
+        callback = greenlet.getcurrent().switch
+        counts = dict((i, 0) for i in range(5))
+
+        lets = [
+            greenlet.greenlet(partial(
+                partial(
+                    copy_context().run,
+                    self._increment
+                ) if propagate else self._increment,
+                greenlet_id=i,
+                ctx_var=id_var,
+                callback=callback,
+                counts=counts,
+                expect=0 if propagate else None,
+            ))
+            for i in range(1, 5)
+        ]
+
+        for i in range(2):
+            counts[id_var.get()] += 1
+            for let in lets:
+                let.switch()
+
+        self.assertEqual(set(counts.values()), {2})
+
+    def test_context_propagated(self):
+        self._new_ctx_run(self._test_context, True)
+
+    def test_context_not_propagated(self):
+        self._new_ctx_run(self._test_context, False)


### PR DESCRIPTION
Add support for switching the `context` thread state entry within the greenlet library. Add tests of the contextvars behavior.

With the addition of PEP 567 ContextVars to the interpreter state in Python 3.7, the switches performed by the greenlet library no longer capture enough of the interpreter state to provide a "seamless" transition. There are certain sequences of greenlet switches which can produce errors within the interpreter, and other situations where greenlet switches produce nonsense ContextVar values (i.e. the context visible to a greenlet will match the most recent context interpreter-wide, rather than the most recent context to that greenlet).

I have opted to leave the `tstate->context` variable `NULL` for newly created greenlets, which matches the behavior of new threads. This will leave the new greenlet with a completely blank-slate context. From the blank slate, it is easy for users to enter their preferred context using `Context.run`.