### PR TITLE
Test on ppc64le in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ matrix:
   - arch: amd64
     python: 2.7
     dist: bionic
+  - arch: ppc64le
+    python: 2.7
+    dist: bionic
   - arch: amd64
     python: 3.2
     dist: precise
@@ -24,28 +27,43 @@ matrix:
   - arch: amd64
     python: 3.4
     dist: xenial
+  - arch: ppc64le
+    python: 3.4
+    dist: xenial
   - arch: arm64
     python: 3.5
     dist: bionic
   - arch: amd64
+    python: 3.5
+    dist: bionic
+  - arch: ppc64le
     python: 3.5
     dist: bionic
   - arch: arm64
     python: 3.6
     dist: bionic
   - arch: amd64
+    python: 3.6
+    dist: bionic
+  - arch: ppc64le
     python: 3.6
     dist: bionic
   - arch: arm64
     python: 3.7
     dist: bionic
   - arch: amd64
+    python: 3.7
+    dist: bionic
+  - arch: ppc64le
     python: 3.7
     dist: bionic
   - arch: arm64
     python: 3.8
     dist: bionic
   - arch: amd64
+    python: 3.8
+    dist: bionic
+  - arch: ppc64le
     python: 3.8
     dist: bionic
 


### PR DESCRIPTION
As with ARM64, Travis CI supports ppc64le ("Power") now. Greenlets require arch-specific code for each platform, so it would be nice to test there too. I've mimicked the jobs that ARM64 does.

If any issues come up with the Power build in future, feel free to tag me in and I'll have a look - I have access to Power systems at work.