### PR TITLE
Enable AArch64 wheels to be built, automate them in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ sudo: false
 
 matrix:
   include:
-  - arch: amd64
+  - stage: test
+    arch: amd64
     python: 2.6
     dist: precise
   - arch: arm64
@@ -66,6 +67,21 @@ matrix:
   - arch: ppc64le
     python: 3.8
     dist: bionic
+
+  # Build and deploy the aarch64 wheels on tagged releases to master branch
+  - stage: deploy
+    arch: arm64
+    dist: bionic
+    python: 3.8
+    services:
+      - docker
+    if: tag IS present AND repo = python-greenlet/greenlet
+    install:
+      - python3 -m pip install twine
+    script:
+      - ./make-manylinux manylinux2014_aarch64
+    after_success:
+      - python3 -m twine upload --skip-existing --repository-url=https://test.pypi.org/legacy/ wheelhouse/*
 
 install: python setup.py build_ext -i
 

--- a/make-manylinux
+++ b/make-manylinux
@@ -1,7 +1,11 @@
 #!/bin/bash
-set -e
+set -e -x
 export PYTHONUNBUFFERED=1
 export PYTHONDONTWRITEBYTECODE=1
+
+if [[ -z ${PLAT+x} ]]; then
+    PLAT=$1
+fi
 
 if [ -d /greenlet -a -d /opt/python ]; then
     # Running inside docker
@@ -10,10 +14,10 @@ if [ -d /greenlet -a -d /opt/python ]; then
     for variant in /opt/python/*; do
         rm -rf dist build *.egg-info
         $variant/bin/python setup.py clean --all bdist_wheel
-        auditwheel repair dist/*.whl
+        auditwheel repair dist/*.whl --plat $PLAT -w wheelhouse
     done
     rm -rf dist build *.egg-info
     exit 0
 fi
 
-docker run --rm -ti -v "$(pwd):/greenlet:Z" quay.io/pypa/manylinux1_x86_64 /greenlet/$(basename $0)
+docker run -e PLAT=$PLAT --rm -v "$(pwd):/greenlet:Z" quay.io/pypa/$PLAT /greenlet/$(basename $0)


### PR DESCRIPTION
## What this PR does
Updates make-manylinux to be parameterized so can build multiple wheel types.
To build a wheel for manylinux2014_aarch64 for instance, you call make-manylinux as:
- ./make-manylinux manylinux2014_aarch64

Updated .travis.yml to automatically build and upload wheels on tagged pushes to the
master branch so long as TWINE_USERNAME and TWINE_PASSWORD is defined in Travis-CI
settings.  Right now it only builds AArch64 wheels, but can easily be extended to build other wheels.

Related to issue: https://github.com/python-greenlet/greenlet/issues/175