### PR TITLE
Officially drop support for 2.4/5/6 and 3.0/1/2/3/4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ sudo: false
 
 matrix:
   include:
-  - arch: amd64
-    python: 2.6
-    dist: precise
   - arch: arm64
     python: 2.7
     dist: bionic
@@ -15,18 +12,6 @@ matrix:
   - arch: ppc64le
     python: 2.7
     dist: bionic
-  - arch: amd64
-    python: 3.3
-    dist: precise
-  - arch: arm64
-    python: 3.4
-    dist: xenial
-  - arch: amd64
-    python: 3.4
-    dist: xenial
-  - arch: ppc64le
-    python: 3.4
-    dist: xenial
   - arch: arm64
     python: 3.5
     dist: bionic
@@ -63,7 +48,8 @@ matrix:
   - arch: ppc64le
     python: 3.8
     dist: bionic
+  - python: 3.9-dev
 
-install: python setup.py build_ext -i
+install: pip install -U -e .[test]
 
 script: python run-tests.py

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,9 @@
 - (Packaging) Stop asking setuptools to build both .tar.gz and .zip
   sdists. PyPI has standardized on .tar.gz for all platforms.
 - (Documentation) Publish the change log to https://greenlet.readthedocs.io
-- Drop support for Python 3.0, 3.1 and 3.2.
+- Drop support for Python 2.4, 2.5, 2.6, 3.0, 3.1, 3.2 and 3.4.
+  The project metadata now includes the ``python_requires`` data to
+  help installation tools understand supported versions.
 
 
 0.4.17 (2020-09-22)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,3 @@
-version: 0.4.17.{build}
 environment:
   global:
     # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
@@ -15,22 +14,6 @@ environment:
     - PYTHON_ROOT: "C:\\Python27-x64"
       PYTHON_ARCH: "64"
       PYTHON_VERSION: "2.7.x"
-
-    - PYTHON_ROOT: "C:\\Python33"
-      PYTHON_ARCH: "32"
-      PYTHON_VERSION: "3.3.x"
-
-    - PYTHON_ROOT: "C:\\Python33-x64"
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.3.x"
-
-    - PYTHON_ROOT: "C:\\Python34"
-      PYTHON_ARCH: "32"
-      PYTHON_VERSION: "3.4.x"
-
-    - PYTHON_ROOT: "C:\\Python34-x64"
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.4.x"
 
     - PYTHON_ROOT: "C:\\Python35"
       PYTHON_ARCH: "32"
@@ -76,14 +59,14 @@ install:
   - "%CMD_IN_ENV% pip install --upgrade -r dev-requirements.txt"
 
 build_script:
-  - "%CMD_IN_ENV% python setup.py build"
+  - "%CMD_IN_ENV% python -m pip install -U -e .[test]"
 
+# XXX: setup.py test is deprecated
 test_script:
   - "%CMD_IN_ENV% python setup.py test"
 
 after_test:
   - "%CMD_IN_ENV% python setup.py bdist_wheel"
-  - "%CMD_IN_ENV% python setup.py bdist_egg"
 
 artifacts:
   - path: dist\*

--- a/greenlet.h
+++ b/greenlet.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#define GREENLET_VERSION "0.4.17"
+#define GREENLET_VERSION "1.0.0.dev0"
 
 #if PY_VERSION_HEX >= 0x030700A3
 #  define GREENLET_USE_EXC_INFO

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ else:
 
 setup(
     name="greenlet",
-    version='0.4.17',
+    version='1.0.0.dev0',
     description='Lightweight in-process concurrent programming',
     long_description=readfile("README.rst"),
     url="https://github.com/python-greenlet/greenlet",
@@ -86,13 +86,8 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.4',
-        'Programming Language :: Python :: 2.5',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
@@ -106,6 +101,7 @@ setup(
             'Sphinx',
         ]
     },
+    python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",
     # XXX: This is deprecated. appveyor.yml still uses it though.
     test_suite='tests.test_collector',
     zip_safe=False,


### PR DESCRIPTION
Change the classifiers, update the version number, remove those versions from CI, add `python_requires`. (Hmm, updating the version was two steps because its copied into `greenlet.h`. Better if that was one step—one source of truth; perhaps setup.py could update `greenlet.h`? Or we'll need an extension for zest.releaser.)

This does not yet make any code changes.

Using 3.4 as the cutoff point because that's where the biggest drop in usage comes; it's also no longer supported by gevent or eventlet.

Fixes #186