### PR TITLE
Remove redundant code for Python 2.4-2.6 and 3.0-3.3

### DIFF
--- a/greenlet.h
+++ b/greenlet.h
@@ -57,10 +57,6 @@ typedef struct _greenlet {
 #define PyGreenlet_ACTIVE(op)     (((PyGreenlet*)(op))->stack_start != NULL)
 #define PyGreenlet_GET_PARENT(op) (((PyGreenlet*)(op))->parent)
 
-#if (PY_MAJOR_VERSION == 2 && PY_MINOR_VERSION >= 7) || (PY_MAJOR_VERSION == 3 && PY_MINOR_VERSION >= 1) || PY_MAJOR_VERSION > 3
-#define GREENLET_USE_PYCAPSULE
-#endif
-
 /* C API functions */
 
 /* Total number of symbols that are exported */
@@ -138,27 +134,10 @@ static void **_PyGreenlet_API = NULL;
 	 _PyGreenlet_API[PyGreenlet_SetParent_NUM])
 
 /* Macro that imports greenlet and initializes C API */
-#ifdef GREENLET_USE_PYCAPSULE
 #define PyGreenlet_Import() \
 { \
 	_PyGreenlet_API = (void**)PyCapsule_Import("greenlet._C_API", 0); \
 }
-#else
-#define PyGreenlet_Import() \
-{ \
-	PyObject *module = PyImport_ImportModule("greenlet"); \
-	if (module != NULL) { \
-		PyObject *c_api_object = PyObject_GetAttrString( \
-			module, "_C_API"); \
-		if (c_api_object != NULL && PyCObject_Check(c_api_object)) { \
-			_PyGreenlet_API = \
-				(void **) PyCObject_AsVoidPtr(c_api_object); \
-			Py_DECREF(c_api_object); \
-		} \
-		Py_DECREF(module); \
-	} \
-}
-#endif
 
 #endif /* GREENLET_MODULE */
 

--- a/make-win-release
+++ b/make-win-release
@@ -4,14 +4,8 @@ import sys, os, subprocess, re
 
 common_dist = ("bdist_wheel", "bdist_egg", "test")
 pyver2dist = {
-    "Python26": common_dist,
-    "Python26x64": common_dist,
     "Python27": common_dist,
     "Python27x64": common_dist,
-    "Python33": common_dist,
-    "Python33x64": common_dist,
-    "Python34": common_dist,
-    "Python34x64": common_dist,
     "Python35": common_dist,
     "Python35x64": common_dist,
 }

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,6 @@ if ((sys.platform == "openbsd4" and os.uname()[-1] == "i386")
 
 
 def readfile(filename):
-    # The with statement is from Python 2.6, meaning we definitely no longer
-    # support 2.4 or 2.5. I strongly suspect that's not a problem; we'll be dropping
-    # our claim to support them very soon anyway.
     with open(filename, 'r') as f:
         return f.read()
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,35 +2,10 @@
 commands={envpython} run-tests.py -nq
 sitepackages=False
 
-# this is 32 bit only
-[testenv:x-py25]
-basepython=/usr/bin/python2.5
-
-# test both 32 bit and 64 bit on OS X
-[testenv:x-py26]
-commands=/usr/bin/arch -i386 {envpython} run-tests.py -qn
-	 /usr/bin/arch -x86_64 {envpython} run-tests.py -qn
-basepython=/usr/bin/python2.6
-
 [testenv:x-py27]
 commands=/usr/bin/arch -i386 {envpython} run-tests.py -qn
 	 /usr/bin/arch -x86_64 {envpython} run-tests.py -qn
 basepython=/usr/bin/python2.7
-
-
-# test with specific gcc version on OS X
-[testenv:x-py26-gcc40]
-commands=/usr/bin/arch -i386 {envpython} run-tests.py -qn
-	 /usr/bin/arch -x86_64 {envpython} run-tests.py -qn
-basepython=/usr/bin/python2.6
-setenv=
-	CC=gcc-4.0
-
-[testenv:x-py26-gcc42]
-commands=/usr/bin/arch -i386 {envpython} run-tests.py -qn
-	 /usr/bin/arch -x86_64 {envpython} run-tests.py -qn
-basepython=/usr/bin/python2.6
-setenv=	CC=gcc-4.2
 
 
 [testenv:docs]


### PR DESCRIPTION
For https://github.com/python-greenlet/greenlet/issues/186, follow on from https://github.com/python-greenlet/greenlet/pull/192.