### PR TITLE
Copy ppc64 linux implementation to ppc64 AIX

### DIFF
--- a/platform/switch_ppc64_aix.h
+++ b/platform/switch_ppc64_aix.h
@@ -52,11 +52,7 @@
 
 #ifdef SLP_EVAL
 
-#if _CALL_ELF == 2
-#define STACK_MAGIC 4
-#else
 #define STACK_MAGIC 6
-#endif
 
 #if defined(__ALTIVEC__)
 #define ALTIVEC_REGS \

--- a/platform/switch_ppc64_aix.h
+++ b/platform/switch_ppc64_aix.h
@@ -1,0 +1,107 @@
+/*
+ * this is the internal transfer function.
+ *
+ * HISTORY
+ * 16-Oct-20  Jesse Gorzinski <jgorzins@us.ibm.com>
+ *      Copied from Linux PPC64 implementation
+ * 04-Sep-18  Alexey Borzenkov  <snaury@gmail.com>
+ *      Workaround a gcc bug using manual save/restore of r30
+ * 21-Mar-18  Tulio Magno Quites Machado Filho  <tuliom@linux.vnet.ibm.com>
+ *      Added r30 to the list of saved registers in order to fully comply with
+ *      both ppc64 ELFv1 ABI and the ppc64le ELFv2 ABI, that classify this
+ *      register as a nonvolatile register used for local variables.
+ * 21-Mar-18  Laszlo Boszormenyi  <gcs@debian.org>
+ *      Save r2 (TOC pointer) manually.
+ * 10-Dec-13  Ulrich Weigand  <uweigand@de.ibm.com>
+ *	Support ELFv2 ABI.  Save float/vector registers.
+ * 09-Mar-12 Michael Ellerman <michael@ellerman.id.au>
+ *      64-bit implementation, copied from 32-bit.
+ * 07-Sep-05 (py-dev mailing list discussion)
+ *      removed 'r31' from the register-saved.  !!!! WARNING !!!!
+ *      It means that this file can no longer be compiled statically!
+ *      It is now only suitable as part of a dynamic library!
+ * 14-Jan-04  Bob Ippolito <bob@redivi.com>
+ *      added cr2-cr4 to the registers to be saved.
+ *      Open questions: Should we save FP registers?
+ *      What about vector registers?
+ *      Differences between darwin and unix?
+ * 24-Nov-02  Christian Tismer  <tismer@tismer.com>
+ *      needed to add another magic constant to insure
+ *      that f in slp_eval_frame(PyFrameObject *f)
+ *      STACK_REFPLUS will probably be 1 in most cases.
+ *      gets included into the saved stack area.
+ * 04-Oct-02  Gustavo Niemeyer <niemeyer@conectiva.com>
+ *      Ported from MacOS version.
+ * 17-Sep-02  Christian Tismer  <tismer@tismer.com>
+ *      after virtualizing stack save/restore, the
+ *      stack size shrunk a bit. Needed to introduce
+ *      an adjustment STACK_MAGIC per platform.
+ * 15-Sep-02  Gerd Woetzel       <gerd.woetzel@GMD.DE>
+ *      slightly changed framework for sparc
+ * 29-Jun-02  Christian Tismer  <tismer@tismer.com>
+ *      Added register 13-29, 31 saves. The same way as
+ *      Armin Rigo did for the x86_unix version.
+ *      This seems to be now fully functional!
+ * 04-Mar-02  Hye-Shik Chang  <perky@fallin.lv>
+ *      Ported from i386.
+ * 31-Jul-12  Trevor Bowen    <trevorbowen@gmail.com>
+ *      Changed memory constraints to register only.
+ */
+
+#define STACK_REFPLUS 1
+
+#ifdef SLP_EVAL
+
+#if _CALL_ELF == 2
+#define STACK_MAGIC 4
+#else
+#define STACK_MAGIC 6
+#endif
+
+#if defined(__ALTIVEC__)
+#define ALTIVEC_REGS \
+       "v20", "v21", "v22", "v23", "v24", "v25", "v26", "v27", \
+       "v28", "v29", "v30", "v31",
+#else
+#define ALTIVEC_REGS
+#endif
+
+#define REGS_TO_SAVE "r14", "r15", "r16", "r17", "r18", "r19", "r20",  \
+       "r21", "r22", "r23", "r24", "r25", "r26", "r27", "r28", "r29",  \
+       "r31",                                                    \
+       "fr14", "fr15", "fr16", "fr17", "fr18", "fr19", "fr20", "fr21", \
+       "fr22", "fr23", "fr24", "fr25", "fr26", "fr27", "fr28", "fr29", \
+       "fr30", "fr31", \
+       ALTIVEC_REGS \
+       "cr2", "cr3", "cr4"
+
+static int
+slp_switch(void)
+{
+    register int err;
+    register long *stackref, stsizediff;
+    void * toc;
+    void * r30;
+    __asm__ volatile ("" : : : REGS_TO_SAVE);
+    __asm__ volatile ("std 2, %0" : "=m" (toc));
+    __asm__ volatile ("std 30, %0" : "=m" (r30));
+    __asm__ ("mr %0, 1" : "=r" (stackref) : );
+    {
+        SLP_SAVE_STATE(stackref, stsizediff);
+        __asm__ volatile (
+            "mr 11, %0\n"
+            "add 1, 1, 11\n"
+            : /* no outputs */
+            : "r" (stsizediff)
+            : "11"
+            );
+        SLP_RESTORE_STATE();
+    }
+    __asm__ volatile ("ld 30, %0" : : "m" (r30));
+    __asm__ volatile ("ld 2, %0" : : "m" (toc));
+    __asm__ volatile ("" : : : REGS_TO_SAVE);
+    __asm__ volatile ("li %0, 0" : "=r" (err));
+    return err;
+}
+
+#endif

--- a/slp_platformselect.h
+++ b/slp_platformselect.h
@@ -18,6 +18,8 @@
 #include "platform/switch_ppc_linux.h" /* gcc on PowerPC */
 #elif defined(__GNUC__) && defined(__ppc__) && defined(__APPLE__)
 #include "platform/switch_ppc_macosx.h" /* Apple MacOS X on PowerPC */
+#elif defined(__GNUC__) && defined(__powerpc64__) && defined(_AIX)
+#include "platform/switch_ppc64_aix.h" /* gcc on AIX/PowerPC 64-bit */
 #elif defined(__GNUC__) && defined(_ARCH_PPC) && defined(_AIX)
 #include "platform/switch_ppc_aix.h" /* gcc on AIX/PowerPC */
 #elif defined(__GNUC__) && defined(sparc)


### PR DESCRIPTION
Implements the suggestion in #159. 

Seems to fix `bpython` problem as reported in #145. 

However, the first test (`tests.test_cpp.CPPTests`) fails with a core dump. Relevant portion of the stack trace is:
```
#3  0x0900000000310468 in abort () from /QOpenSys/usr/lib/libc.a(shr_64.o)
#4  0x0900000005ed5600 in __gnu_cxx::__verbose_terminate_handler() () from /QOpenSys/pkgs/lib/libstdc++.so.6(shr_64.o)
#5  0x0900000005ee2f4c in __cxxabiv1::__terminate(void (*)()) () from /QOpenSys/pkgs/lib/libstdc++.so.6(shr_64.o)
#6  0x0900000005ed53cc in std::terminate() () from /QOpenSys/pkgs/lib/libstdc++.so.6(shr_64.o)
#7  0x0900000005ee2c00 in __cxa_throw () from /QOpenSys/pkgs/lib/libstdc++.so.6(shr_64.o)
#8  0x0900000027f526a0 in test_exception_throw(int) () from /home/JGORZINS/projects/greenlet/build/tests/lib.os400-powerpc64-3.6/_test_extension_cpp.so
#9  0x0900000027f524f8 in test_exception_switch_recurse(int, int) ()
   from /home/JGORZINS/projects/greenlet/build/tests/lib.os400-powerpc64-3.6/_test_extension_cpp.so
#10 0x0900000027f52738 in test_exception_switch(_object*, _object*) ()
   from /home/JGORZINS/projects/greenlet/build/tests/lib.os400-powerpc64-3.6/_test_extension_cpp.so
#11 0x0900000002de233c in PyCFunction_Call () from /QOpenSys/pkgs/lib/libpython3.6m.so
#12 0x0900000002cd43d4 in PyObject_Call () from /QOpenSys/pkgs/lib/libpython3.6m.so
```
So this is not fully baked, and to be honest, I'm not qualified to properly debug. Opening the PR regardless since "kinda working" is better than "completely broken." (though that's not a universally-agreed-upon stance)
I can still try to recruit someone who can fix the failing tests (it might be as simple as compilation flags or something).

Plus, having a working `bpython` in my IBM i programming environment is nice! 