### PR TITLE
Test on Python 3.9 final

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,62 +1,45 @@
 language: python
 cache: pip
+dist: bionic
 
 matrix:
   include:
   - arch: arm64
     python: 2.7
-    dist: bionic
   - arch: amd64
     python: 2.7
-    dist: bionic
   - arch: ppc64le
     python: 2.7
-    dist: bionic
   - arch: arm64
     python: 3.5
-    dist: bionic
   - arch: amd64
     python: 3.5
-    dist: bionic
   - arch: ppc64le
     python: 3.5
-    dist: bionic
   - arch: arm64
     python: 3.6
-    dist: bionic
   - arch: amd64
     python: 3.6
-    dist: bionic
   - arch: ppc64le
     python: 3.6
-    dist: bionic
   - arch: arm64
     python: 3.7
-    dist: bionic
   - arch: amd64
     python: 3.7
-    dist: bionic
   - arch: ppc64le
     python: 3.7
-    dist: bionic
   - arch: arm64
     python: 3.8
-    dist: bionic
   - arch: amd64
     python: 3.8
-    dist: bionic
   - arch: ppc64le
     python: 3.8
-    dist: bionic
   - arch: arm64
     python: 3.9
-    dist: bionic
   - arch: amd64
     python: 3.9
-    dist: bionic
   - arch: ppc64le
     python: 3.9
-    dist: bionic
 
 install: pip install -U -e .[test]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-sudo: false
+cache: pip
 
 matrix:
   include:
@@ -48,7 +48,15 @@ matrix:
   - arch: ppc64le
     python: 3.8
     dist: bionic
-  - python: 3.9-dev
+  - arch: arm64
+    python: 3.9
+    dist: bionic
+  - arch: amd64
+    python: 3.9
+    dist: bionic
+  - arch: ppc64le
+    python: 3.9
+    dist: bionic
 
 install: pip install -U -e .[test]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,44 +2,18 @@ language: python
 cache: pip
 dist: bionic
 
-matrix:
-  include:
-  - arch: arm64
-    python: 2.7
-  - arch: amd64
-    python: 2.7
-  - arch: ppc64le
-    python: 2.7
-  - arch: arm64
-    python: 3.5
-  - arch: amd64
-    python: 3.5
-  - arch: ppc64le
-    python: 3.5
-  - arch: arm64
-    python: 3.6
-  - arch: amd64
-    python: 3.6
-  - arch: ppc64le
-    python: 3.6
-  - arch: arm64
-    python: 3.7
-  - arch: amd64
-    python: 3.7
-  - arch: ppc64le
-    python: 3.7
-  - arch: arm64
-    python: 3.8
-  - arch: amd64
-    python: 3.8
-  - arch: ppc64le
-    python: 3.8
-  - arch: arm64
-    python: 3.9
-  - arch: amd64
-    python: 3.9
-  - arch: ppc64le
-    python: 3.9
+arch:
+  - arm64
+  - amd64
+  - ppc64le
+
+python:
+  - 2.7
+  - 3.5
+  - 3.6
+  - 3.7
+  - 3.8
+  - 3.9
 
 install: pip install -U -e .[test]
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,14 @@ environment:
       PYTHON_ARCH: "64"
       PYTHON_VERSION: "3.8.x"
 
+    - PYTHON_ROOT: "C:\\Python39"
+      PYTHON_ARCH: "32"
+      PYTHON_VERSION: "3.9.x"
+
+    - PYTHON_ROOT: "C:\\Python39-x64"
+      PYTHON_ARCH: "64"
+      PYTHON_VERSION: "3.9.x"
+
 install:
   - "SET PATH=%PYTHON_ROOT%;%PYTHON_ROOT%\\Scripts;%PATH%"
   - "python --version"


### PR DESCRIPTION
Python 3.9 final is now available on both Travis CI and AppVeyor.

We can also remove `sudo: false` from Travis as it no longer has any effect, and simplify the config by refactoring.