### PR TITLE
Build and test in the manylinux environment for amd64 and aarch64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,23 @@
 language: python
-cache: pip
-dist: bionic
 
+dist: bionic
+osx_image: xcode11.4
+
+env:
+    global:
+        - PYTHONHASHSEED=8675309
+        - PYTHONUNBUFFERED=1
+        - PYTHONDONTWRITEBYTECODE=1
+        - PIP_UPGRADE_STRATEGY=eager
+        # Don't get warnings about Python 2 support being deprecated. We
+        # know. The env var works for pip 20.
+        - PIP_NO_PYTHON_VERSION_WARNING=1
+        - PIP_NO_WARN_SCRIPT_LOCATION=1
+        # Uploading built wheels for releases.
+        # TWINE_PASSWORD is encrypted and stored directly in the
+        # travis repo settings.
+        - TWINE_USERNAME="__token__"
 arch:
-  - arm64
-  - amd64
   - ppc64le
 
 python:
@@ -15,8 +28,115 @@ python:
   - 3.8
   - 3.9
 
-install: pip install -U -e .[test,docs]
+install:
+  - python -m pip install -U pip
+  - python -m pip install -U twine
+  - python setup.py bdist_wheel
+  - python -m pip install -U -e .[test,docs]
+  - ls -l dist
+  - twine check dist/*
 
 script:
   - python -m unittest discover -v greenlet.tests
   - sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctest2
+
+jobs:
+  fast_finish: true
+  include:
+    # The manylinux builds and tests.
+    # These take awhile, so get them started while others proceed in parallel.
+    - stage: test
+      name: x86_64 manylinux tests and wheels (all Pythons)
+      language: python
+      python: 3.8
+      os: linux
+      arch: amd64
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2010_x86_64
+      install:
+        - python -m pip install -U pip twine
+        - docker pull $DOCKER_IMAGE
+      script: bash make-manylinux
+    - stage: test
+      name: aarch64 manylinux tests and wheels (all Pythons)
+      language: python
+      os: linux
+      python: 3.8
+      arch: arm64
+      services: docker
+      env: DOCKER_IMAGE=quay.io/pypa/manylinux2014_aarch64
+      install:
+        - python -m pip install -U pip twine
+        - docker pull $DOCKER_IMAGE
+      script: bash ./make-manylinux
+
+    # It's important to use 'macpython' builds to get the least
+    # restrictive wheel tag. It's also important to avoid
+    # 'homebrew 3' because it floats instead of being a specific
+    # version.
+    # XXX: This doesn't seem to properly save the pip cache. Is it
+    # because of 'language: generic'? Trying to list the directory specifically.
+    - name: Python 2.7 wheels for MacOS
+      os: osx
+      language: generic
+      # We require at least 2.7.15 to upload wheels.
+      # See https://github.com/zopefoundation/BTrees/issues/113
+      env: TERRYFY_PYTHON='macpython 2.7.18'
+    # Can't correctly upload.
+    # - name: Python 3.5 wheels for MacOS
+    #   os: osx
+    #   language: generic
+    #   env: TERRYFY_PYTHON='macpython 3.5'
+    - name: Python 3.6 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.6.1'
+    - name: Python 3.7 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.7.0'
+    - name: Python 3.8 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.8.0'
+    - name: Python 3.9 wheels for MacOS
+      os: osx
+      language: generic
+      env: TERRYFY_PYTHON='macpython 3.9.0'
+
+before_install:
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      git clone https://github.com/MacPython/terryfy
+      source terryfy/travis_tools.sh
+      get_python_environment $TERRYFY_PYTHON venv
+    fi
+
+after_success:
+  - |
+    if [[ -n "$DOCKER_IMAGE" ]]; then
+      python -mensurepip
+      python -m pip install -U pip
+      python -m pip install -U twine
+      ls -l wheelhouse
+      twine check wheelhouse/*
+      if [[ $TRAVIS_TAG ]]; then
+        twine upload --skip-existing wheelhouse/*
+      fi
+    fi
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      ls -l dist
+      twine check dist/*
+      if [[ $TRAVIS_TAG ]]; then
+        python -m twine upload --skip-existing dist/*
+      fi
+    fi
+
+cache:
+  pip: true
+  directories:
+    - $HOME/Library/Caches/pip
+
+before_cache:
+    - rm -f $HOME/.cache/pip/log/debug.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,12 +26,22 @@ environment:
     # Enable this if debugging a resource leak. Otherwise
     # it slows things down.
     # PYTHONTRACEMALLOC: 10
+    # Upload settings for twine.
+    TWINE_USERNAME: "__token__"
+    TWINE_PASSWORD:
+      secure: 9JKBIB2o2S18+REaEqzUrP/1g08eRdX3eEa7D/BBN5ae0XHTlrPqbvRTNJceiUa/o3r4bejFF3o0xA69ueMd+09PGKAAAfpQnwnQPInuLVkOq3mprNk4wW0GyWLFzI3WqZhYnWH7PZtmG4Kr7mNOyd6Qdi773kN3Hn7CNhvk+ik/K3zbsGerb2YYloM/KIQSJbgdEqNcIIItoqrZzg/cqiM/47Pz7ZzcGDvevD8Nx/0lVGqFVJnj8cMevwa9iDPYn7fB59Y1GEEbtBjenrWr1Q==
 
   matrix:
     # http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python39-x64"
       PYTHON_ARCH: "64"
+      PYTHON_VERSION: "3.9.x"
+      PYTHON_EXE: python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+
+    - PYTHON: "C:\\Python39"
+      PYTHON_ARCH: "32"
       PYTHON_VERSION: "3.9.x"
       PYTHON_EXE: python
       APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
@@ -158,3 +168,8 @@ after_test:
 
 artifacts:
   - path: dist\*
+
+deploy_script:
+  - ps: if ($env:APPVEYOR_REPO_TAG -eq $TRUE) { pip install twine; twine upload --skip-existing dist/* }
+
+deploy: on

--- a/make-manylinux
+++ b/make-manylinux
@@ -1,19 +1,52 @@
 #!/bin/bash
+# Initially based on a snippet from the greenlet project.
+# This needs to be run from the root of the project.
+# To update: docker pull quay.io/pypa/manylinux2010_x86_64
 set -e
 export PYTHONUNBUFFERED=1
 export PYTHONDONTWRITEBYTECODE=1
+# Use a fixed hash seed for reproducability
+export PYTHONHASHSEED=8675309
+export CI=1
+export TRAVIS=true
+# Don't get warnings about Python 2 support being deprecated. We
+# know. The env var works for pip 20.
+export PIP_NO_PYTHON_VERSION_WARNING=1
+export PIP_NO_WARN_SCRIPT_LOCATION=1
+
 
 if [ -d /greenlet -a -d /opt/python ]; then
     # Running inside docker
-    cd /greenlet
-    rm -rf wheelhouse
-    for variant in /opt/python/*; do
-        rm -rf dist build *.egg-info
-        $variant/bin/python setup.py clean --all bdist_wheel
-        auditwheel repair dist/*.whl
+
+    # Build in an isolated directory
+    mkdir /tmp/build
+    cd /tmp/build
+    git clone /greenlet greenlet
+    cd greenlet
+
+    mkdir -p /greenlet/wheelhouse
+    OPATH="$PATH"
+    which auditwheel
+    for variant in `ls -d /opt/python/cp{27,35,36,37,38,39}*`; do
+        export PATH="$variant/bin:$OPATH"
+        echo "Building $variant $(python --version)"
+
+        python -mpip install -U pip
+        python setup.py bdist_wheel
+        python -mpip install -U .
+        python -m unittest discover -v greenlet.tests
+        PATH="$OPATH" auditwheel repair dist/greenlet*.whl
+        cp wheelhouse/greenlet*.whl /greenlet/wheelhouse
+
+        rm -rf build
+        rm -f dist/greenlet*.whl
+
     done
-    rm -rf dist build *.egg-info
+
     exit 0
 fi
 
-docker run --rm -ti -v "$(pwd):/greenlet:Z" quay.io/pypa/manylinux1_x86_64 /greenlet/$(basename $0)
+# Mount the current directory as /greenlet
+# Can't use -i on Travis with arm64, "input device not a tty"
+docker run --rm -v "$(pwd):/greenlet"  ${DOCKER_IMAGE:-quay.io/pypa/manylinux2010_x86_64} /greenlet/$(basename $0)
+ls -l wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -99,6 +99,7 @@ setup(
     version='1.0.0.dev0',
     description='Lightweight in-process concurrent programming',
     long_description=readfile("README.rst"),
+    long_description_content_type="text/x-rst",
     url="https://greenlet.readthedocs.io/",
     project_urls={
         'Bug Tracker': 'https://github.com/python-greenlet/greenlet/issues',


### PR DESCRIPTION
Also add macOS.

All of these environments will upload built wheels on release.

AppVeyor now also uploads built wheels on releases.

Fixes #175 and fixes #191. Supersedes #176 