### PR TITLE
Move definition of __version__ into __init__.py.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@
 - Add partial support for AIX ppc64 and IBM i. Thanks to Jesse
   Gorzinski and Kevin Adler. See `PR 197
   <https://github.com/python-greenlet/greenlet/pull/197>`_.
+- (C API) The undocumented ``GREENLET_VERSION`` macro that defined a string
+  giving the greenlet version is now deprecated and will not be updated.
 
 0.4.17 (2020-09-22)
 ===================

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[zest.releaser]
+python-file-with-version = src/greenlet/__init__.py

--- a/setup.py
+++ b/setup.py
@@ -94,9 +94,20 @@ else:
                 include_dirs=[GREENLET_HEADER_DIR]),
         )
 
+
+def get_greenlet_version():
+    with open('src/greenlet/__init__.py') as f:
+        looking_for = '__version__ = \''
+        for line in f:
+            if line.startswith(looking_for):
+                version = line[len(looking_for):-2]
+                return version
+    raise ValueError("Unable to find version")
+
+
 setup(
     name="greenlet",
-    version='1.0.0.dev0',
+    version=get_greenlet_version(),
     description='Lightweight in-process concurrent programming',
     long_description=readfile("README.rst"),
     long_description_content_type="text/x-rst",

--- a/src/greenlet/__init__.py
+++ b/src/greenlet/__init__.py
@@ -25,9 +25,7 @@ __all__ = [
 ###
 # Metadata
 ###
-from ._greenlet import __version__
-# TODO: Move the definition of __version__ here, instead of the
-# C code. zest.releaser will find it here, but not in C.
+__version__ = '1.0.0.dev0'
 from ._greenlet import _C_API # pylint:disable=no-name-in-module
 
 ###

--- a/src/greenlet/greenlet.c
+++ b/src/greenlet/greenlet.c
@@ -5,6 +5,12 @@
 #include "greenlet.h"
 #include "structmember.h"
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
 
 /***********************************************************
 
@@ -1774,11 +1780,6 @@ init_greenlet(void)
 		INITERROR;
 	}
 
-	if (PyModule_AddStringConstant(m, "__version__", GREENLET_VERSION) < 0)
-	{
-		INITERROR;
-	}
-
 #if PY_MAJOR_VERSION >= 3
 	ts_curkey = PyUnicode_InternFromString("__greenlet_ts_curkey");
 	ts_delkey = PyUnicode_InternFromString("__greenlet_ts_delkey");
@@ -1887,3 +1888,7 @@ init_greenlet(void)
 	return m;
 #endif
 }
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -11,7 +11,8 @@
 extern "C" {
 #endif
 
-#define GREENLET_VERSION "1.0.0.dev0"
+/* This is deprecated and undocumented. It does not change. */
+#define GREENLET_VERSION "1.0.0"
 
 #if PY_VERSION_HEX >= 0x030700A3
 #  define GREENLET_USE_EXC_INFO

--- a/src/greenlet/tests/test_version.py
+++ b/src/greenlet/tests/test_version.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 
 import sys
 import os
-import re
 import unittest
 
 import greenlet
@@ -12,47 +11,29 @@ import greenlet
 class VersionTests(unittest.TestCase):
     def test_version(self):
         def find_dominating_file(name):
+            if os.path.exists(name):
+                return name
+
+            tried = []
             here = os.path.abspath(os.path.dirname(__file__))
             for i in range(10):
                 up = ['..'] * i
                 path = [here] + up + [name]
                 fname = os.path.join(*path)
                 fname = os.path.abspath(fname)
+                tried.append(fname)
                 if os.path.exists(fname):
                     return fname
-            raise AssertionError("Could not find file " + name + "; last checked " + fname)
+            raise AssertionError("Could not find file " + name + "; checked " + str(tried))
 
         try:
             setup_py = find_dominating_file('setup.py')
         except AssertionError as e:
             raise unittest.SkipTest("Unable to find setup.py; must be out of tree. " + str(e))
 
-        try:
-            greenlet_h = find_dominating_file('greenlet.h')
-        except AssertionError as e:
-            if '.tox' not in os.path.abspath(os.path.dirname(__file__)):
-                raise
-            # If we're in tox, we can recover.
-            greenlet_h = os.path.join(
-                os.path.dirname(setup_py),
-                'src',
-                'greenlet',
-                'greenlet.h'
-            )
-            if not os.path.exists(greenlet_h):
-                raise # Something must have changed in the layout. Fix this test.
-
-
-        with open(greenlet_h) as f:
-            greenlet_h = f.read()
-
-        hversion, = re.findall('GREENLET_VERSION "(.*)"', greenlet_h)
-
-
 
         invoke_setup = "%s %s --version" % (sys.executable, setup_py)
         with os.popen(invoke_setup) as f:
             sversion = f.read().strip()
 
-        self.assertEqual(sversion, hversion)
         self.assertEqual(sversion, greenlet.__version__)


### PR DESCRIPTION
Instead of getting it from C in the GREENLET_VERSION macro.

Also read this value in setup.py.

This gets us DRY (don't repeat yourself) and compatibility with tools like zest.releaser.