### PR TITLE
Always complie with support for tracing, garbage collection and context vars (where applicable)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,6 +35,13 @@
   <https://github.com/python-greenlet/greenlet/pull/197>`_.
 - (C API) The undocumented ``GREENLET_VERSION`` macro that defined a string
   giving the greenlet version is now deprecated and will not be updated.
+- greenlet is now always built with support for tracing and garbage
+  collection, and, on Python 3.7 and above, support for context
+  variables. The internal and undocumented C preprocessor macros that could be used to
+  alter that at compile time have been removed (no combination other
+  than the defaults was ever tested). This helps define a
+  stable ABI.
+
 
 0.4.17 (2020-09-22)
 ===================

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -20,8 +20,7 @@ greenlet uses Semantic Versions; this includes changes to the ABI
 Releases are made using `zest.releaser
 <https://zestreleaser.readthedocs.io/en/latest/>`_.
 
-.. code-block::
-   :language: shell
+.. code-block:: shell
 
    $ pip install zest.releaser[recommended]
    $ fullrelease

--- a/src/greenlet/__init__.py
+++ b/src/greenlet/__init__.py
@@ -53,7 +53,9 @@ except ImportError:
 
 ###
 # Constants
-# These constants aren't documented and aren't recommended
+# These constants aren't documented and aren't recommended.
+# In 1.0, USE_GC and USE_TRACING are always true, and USE_CONTEXT_VARS
+# is the same as ``sys.version_info[:2] >= 3.7``
 ###
 from ._greenlet import GREENLET_USE_CONTEXT_VARS # pylint:disable=unused-import
 from ._greenlet import GREENLET_USE_GC # pylint:disable=unused-import

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -14,17 +14,6 @@ extern "C" {
 /* This is deprecated and undocumented. It does not change. */
 #define GREENLET_VERSION "1.0.0"
 
-#if PY_VERSION_HEX >= 0x030700A3
-#  define GREENLET_USE_EXC_INFO
-#endif
-
-#ifndef GREENLET_USE_CONTEXT_VARS
-#ifdef Py_CONTEXT_H
-#define GREENLET_USE_CONTEXT_VARS 1
-#else
-#define GREENLET_USE_CONTEXT_VARS 0
-#endif
-#endif
 
 typedef struct _greenlet {
 	PyObject_HEAD
@@ -38,7 +27,7 @@ typedef struct _greenlet {
 	struct _frame* top_frame;
 	int recursion_depth;
 	PyObject* weakreflist;
-#ifdef GREENLET_USE_EXC_INFO
+#if PY_VERSION_HEX >= 0x030700A3
 	_PyErr_StackItem* exc_info;
 	_PyErr_StackItem exc_state;
 #else
@@ -47,7 +36,7 @@ typedef struct _greenlet {
 	PyObject* exc_traceback;
 #endif
 	PyObject* dict;
-#if GREENLET_USE_CONTEXT_VARS
+#if PY_VERSION_HEX >= 0x030700A3
 	PyObject* context;
 #endif
 } PyGreenlet;


### PR DESCRIPTION

Remove undocumented compiler macros that let those things be switched off; they were never tested.

Fixes #207