### PR TITLE
Fix cross compilation of Python ARM64 greenlet extension for Windows ARM64 using llvm-mingw

### DIFF
--- a/src/greenlet/platform/switch_aarch64_gcc.h
+++ b/src/greenlet/platform/switch_aarch64_gcc.h
@@ -26,7 +26,7 @@ slp_switch(void)
 {
 	int err;
 	void *fp;
-        register long *stackref, stsizediff;
+        register int64_t *stackref, stsizediff;
         __asm__ volatile ("" : : : REGS_TO_SAVE);
 	__asm__ volatile ("str x29, %0" : "=m"(fp) : : );
         __asm__ ("mov %0, sp" : "=r" (stackref));

--- a/src/greenlet/slp_platformselect.h
+++ b/src/greenlet/slp_platformselect.h
@@ -6,6 +6,8 @@
 #include "platform/switch_x86_msvc.h" /* MS Visual Studio on X86 */
 #elif defined(MS_WIN64) && defined(_M_X64) && defined(_MSC_VER) || defined(__MINGW64__)
 #include "platform/switch_x64_msvc.h" /* MS Visual Studio on X64 */
+#elif defined(MS_WIN32) && defined(__llvm__) && defined(__aarch64__)
+#include "platform/switch_aarch64_gcc.h" /* LLVM Aarch64 ABI for Windows */
 #elif defined(__GNUC__) && defined(__amd64__) && defined(__ILP32__)
 #include "platform/switch_x32_unix.h" /* gcc on amd64 with x32 ABI */
 #elif defined(__GNUC__) && defined(__amd64__)


### PR DESCRIPTION
The patch adds platform implementation for win32 llvm reusing
platform/switch_aarch64_gcc.h and fixes the stackref type to
int64_t, as long is considered to be 32bit by llvm-mingw.

The .pyd extension for greenlet can be manually built using:
https://github.com/mstorsjo/llvm-mingw.

How to set the env to build a working .pyd:

  * Install mingw64 or mingw32
  * Download the llvm-mingw binaries and add them to path
    https://github.com/mstorsjo/llvm-mingw/releases
  * Download a Python 3.9 build for ARM64 and unzip in greenlet/src/greenlet
    https://github.com/ader1990/cpython-builder/actions/runs/377798403

How to build the .pyd using llvm-mingw:

  * cd greenlet/src/greenlet
  * aarch64-w64-mingw32-clang -c greenlet.c -o greenlet.o -I./cpython/include
  * aarch64-w64-mingw32-clang -shared -o _greenlet.cp39-win_arm64.pyd greenlet.o -L./cpython/libs -l:python3.lib -l:python39.lib

Partially-fixes: https://github.com/python-greenlet/greenlet/issues/220