### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, 3.10.0-beta.1]
         os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v2
@@ -95,10 +95,17 @@ jobs:
         #run: |
         #  docker run --rm --privileged multiarch/qemu-user-static:register --reset
       - name: Build and test greenlet
+        if: matrix.image == 'manylinux2010_x86_64'
         # An alternate way to do this is to run the container directly with a uses:
         # and then the script runs inside it. That may work better with caching.
         # See https://github.com/pyca/bcrypt/blob/f6b5ee2eda76d077c531362ac65e16f045cf1f29/.github/workflows/wheel-builder.yml
-        # The 2010 image is the last one that comes with Python 2.7.
+        # The 2010 image is the last one that comes with Python 2.7,
+        # and only up through the tag 2021-02-06-3d322a5
+        env:
+          DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}:2021-02-06-3d322a5
+        run: bash ./make-manylinux
+      - name: Build and test greenlet (other)
+        if: matrix.image != 'manylinux2010_x86_64'
         env:
           DOCKER_IMAGE: quay.io/pypa/${{ matrix.image }}
         run: bash ./make-manylinux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.9]
-        image: [manylinux2010_x86_64, manylinux2014_aarch64, manylinux2014_ppc64le]
+        image: [manylinux2010_x86_64, manylinux2014_aarch64, manylinux2014_ppc64le, manylinux2014_x86_64]
 
     steps:
       - name: checkout

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,11 @@
  Changes
 =========
 
-1.0.1 (unreleased)
+1.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Add support for Python 3.10. Pre-built binary wheels are not
+  currently available for 3.10.
 
 
 1.0.0 (2021-01-13)

--- a/make-manylinux
+++ b/make-manylinux
@@ -27,7 +27,7 @@ if [ -d /greenlet -a -d /opt/python ]; then
     mkdir -p /greenlet/wheelhouse
     OPATH="$PATH"
     which auditwheel
-    for variant in `ls -d /opt/python/cp{27,35,36,37,38,39}*`; do
+    for variant in `ls -d /opt/python/cp{27,35,36,37,38,39,310}*`; do
         export PATH="$variant/bin:$OPATH"
         echo "Building $variant $(python --version)"
 

--- a/setup.py
+++ b/setup.py
@@ -138,6 +138,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/src/greenlet/greenlet.c
+++ b/src/greenlet/greenlet.c
@@ -100,10 +100,13 @@ extern PyTypeObject PyGreenlet_Type;
 /*
 Python 3.10 beta 1 changed tstate->use_tracing to a nested cframe member.
 See https://github.com/python/cpython/pull/25276
+We have to save and restore this as well.
 */
 #define TSTATE_USE_TRACING(tstate) (tstate->cframe->use_tracing)
+#define GREENLET_USE_CFRAME 1
 #else
 #define TSTATE_USE_TRACING(tstate) (tstate->use_tracing)
+#define GREENLET_USE_CFRAME 0
 #endif
 
 #ifndef Py_SET_REFCNT
@@ -515,6 +518,9 @@ g_switchstack(void)
         current->exc_value = tstate->exc_value;
         current->exc_traceback = tstate->exc_traceback;
 #endif
+#if GREENLET_USE_CFRAME
+        current->cframe = tstate->cframe;
+#endif
     }
     err = slp_switch();
     if (err < 0) { /* error */
@@ -557,6 +563,10 @@ g_switchstack(void)
         tstate->exc_traceback = target->exc_traceback;
 #endif
         green_clear_exc(target);
+
+#if GREENLET_USE_CFRAME
+        tstate->cframe = target->cframe;
+#endif
 
         assert(ts_origin == NULL);
         Py_INCREF(target);
@@ -907,6 +917,9 @@ green_new(PyTypeObject* type, PyObject* args, PyObject* kwds)
         }
         Py_INCREF(ts_current);
         ((PyGreenlet*)o)->parent = ts_current;
+#if GREENLET_USE_CFRAME
+        ((PyGreenlet*)o)->cframe = &PyThreadState_GET()->root_cframe;
+#endif
     }
     return o;
 }
@@ -1611,8 +1624,9 @@ PyGreenlet_SetParent(PyGreenlet* g, PyGreenlet* nparent)
 static PyGreenlet*
 PyGreenlet_New(PyObject* run, PyGreenlet* parent)
 {
+    /* XXX: Why doesn't this call green_new()? There's some duplicate
+     code. */
     PyGreenlet* g = NULL;
-
     g = (PyGreenlet*)PyType_GenericAlloc(&PyGreenlet_Type, 0);
     if (g == NULL) {
         return NULL;
@@ -1635,7 +1649,9 @@ PyGreenlet_New(PyObject* run, PyGreenlet* parent)
             return NULL;
         }
     }
-
+#if GREENLET_USE_CFRAME
+    g->cframe = &PyThreadState_GET()->root_cframe;
+#endif
     return g;
 }
 

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -38,6 +38,9 @@ typedef struct _greenlet {
 #if PY_VERSION_HEX >= 0x030700A3
     PyObject* context;
 #endif
+#if PY_VERSION_HEX >= 0x30A00B1
+    CFrame* cframe;
+#endif
 } PyGreenlet;
 
 #define PyGreenlet_Check(op) PyObject_TypeCheck(op, &PyGreenlet_Type)

--- a/src/greenlet/tests/test_extension_interface.py
+++ b/src/greenlet/tests/test_extension_interface.py
@@ -72,3 +72,6 @@ class CAPITests(unittest.TestCase):
             str(seen[0]),
             'take that sucka!',
             "message doesn't match")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py27,py35,py36,py37,py38,py39,docs
+    py27,py35,py36,py37,py38,py39,py310,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
Fixes #236 and fixes #237 and fixes #240

Locally, the python.org installer for macOS 3.10.0b1 is crashing on the test suite, but versions I've built myself are fine. I'm still trying to figure out what's going on.