### PR TITLE
Port to LoongArch64

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ if (
     #
     # Adding the -Os flag fixes the problem.
     or (is_linux and plat_machine == "riscv64")
+    or (is_linux and plat_machine == "loongarch64")
 ):
     global_compile_args.append("-Os")
 

--- a/src/greenlet/platform/switch_loongarch64_linux.h
+++ b/src/greenlet/platform/switch_loongarch64_linux.h
@@ -1,0 +1,31 @@
+#define STACK_REFPLUS 1
+
+#ifdef SLP_EVAL
+#define STACK_MAGIC 0
+
+#define REGS_TO_SAVE "s0", "s1", "s2", "s3", "s4", "s5", \
+                    "s6", "s7", "s8", "fp", \
+                    "f24", "f25", "f26", "f27", "f28", "f29", "f30", "f31"
+
+static int
+slp_switch(void)
+{
+  register int ret;
+  register long *stackref, stsizediff;
+  __asm__ volatile ("" : : : REGS_TO_SAVE);
+  __asm__ volatile ("move %0, $sp" : "=r" (stackref) : );
+  {
+      SLP_SAVE_STATE(stackref, stsizediff);
+      __asm__ volatile (
+         "add.d $sp, $sp, %0\n\t"
+         : /* no outputs */
+         : "r" (stsizediff)
+         );
+      SLP_RESTORE_STATE();
+  }
+  __asm__ volatile ("" : : : REGS_TO_SAVE);
+  __asm__ volatile ("move %0, $zero" : "=r" (ret) : );
+  return ret;
+}
+
+#endif

--- a/src/greenlet/slp_platformselect.h
+++ b/src/greenlet/slp_platformselect.h
@@ -38,6 +38,8 @@ extern "C" {
 #include "platform/switch_s390_unix.h"	/* Linux/S390 */
 #elif defined(__GNUC__) && defined(__s390x__) && defined(__linux__)
 #include "platform/switch_s390_unix.h"	/* Linux/S390 zSeries (64-bit) */
+#elif defined(__GNUC__) && defined(__loongarch64) && defined(__linux__)
+#include "platform/switch_loongarch64_linux.h"	/* Linux/LoongArch64 */
 #elif defined(__GNUC__) && defined(__arm__)
 #ifdef __APPLE__
 #include <TargetConditionals.h>


### PR DESCRIPTION
```
[root@9d30c71260ba greenlet]# python -m unittest discover -v greenlet.tests
test_break_ctxvars (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_assignment_different_thread (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_assignment_while_running (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_not_propagated (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_propagated_by_context_run (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_propagated_by_setting_attribute (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_context_shared (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_not_broken_if_using_attribute_instead_of_context_run (greenlet.tests.test_contextvars.ContextVarsTests) ... skipped 'ContextVar not supported'
test_contextvars_errors (greenlet.tests.test_contextvars.NoContextVarsTests) ... ok
test_exception_switch (greenlet.tests.test_cpp.CPPTests) ... ok
test_getcurrent (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_new_greenlet (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_raise_greenlet_dead (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_raise_greenlet_error (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_setparent (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_switch (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_switch_kwargs (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_throw (greenlet.tests.test_extension_interface.CAPITests) ... ok
test_circular_greenlet (greenlet.tests.test_gc.GCTests) ... ok
test_dead_circular_ref (greenlet.tests.test_gc.GCTests) ... ok
test_finalizer_crash (greenlet.tests.test_gc.GCTests) ... ok
test_inactive_ref (greenlet.tests.test_gc.GCTests) ... ok
test_generator (greenlet.tests.test_generator.GeneratorTests) ... ok
test_genlet_bad (greenlet.tests.test_generator_nested.NestedGeneratorTests) ... ok
test_genlet_simple (greenlet.tests.test_generator_nested.NestedGeneratorTests) ... ok
test_layered_genlets (greenlet.tests.test_generator_nested.NestedGeneratorTests) ... ok
test_nested_genlets (greenlet.tests.test_generator_nested.NestedGeneratorTests) ... ok
test_permutations (greenlet.tests.test_generator_nested.NestedGeneratorTests) ... ok
test_abstract_subclasses (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_dealloc (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_dealloc_other_thread (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_dealloc_switch_args_not_lost (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_deepcopy (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_exc_state (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_exception (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_frame (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_implicit_parent_with_threads (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_instance_dict (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_issue_245_reference_counting_subclass_no_threads (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_issue_245_reference_counting_subclass_threads (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_parent_equals_None (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_parent_restored_on_kill (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_parent_return_failure (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_recursive_startup (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_run_equals_None (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_send_exception (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_simple (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_switch_kwargs (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_switch_kwargs_to_parent (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_switch_to_another_thread (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_thread_bug (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_threaded_reparent (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_threaded_updatecurrent (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_threads (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_throw_doesnt_crash (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_throw_exception_not_lost (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_tuple_subclass (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_two_children (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_two_recursive_children (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_unexpected_reparenting (greenlet.tests.test_greenlet.TestGreenlet) ... ok
test_dead (greenlet.tests.test_greenlet.TestRepr) ... ok
test_formatting_produces_native_str (greenlet.tests.test_greenlet.TestRepr) ... ok
test_initial (greenlet.tests.test_greenlet.TestRepr) ... ok
test_main_from_other_thread (greenlet.tests.test_greenlet.TestRepr) ... ok
test_main_in_background (greenlet.tests.test_greenlet.TestRepr) ... ok
test_main_while_running (greenlet.tests.test_greenlet.TestRepr) ... ok
test_arg_refs (greenlet.tests.test_leaks.TestLeaks) ... ok
test_issue251_issue252_need_to_collect_in_background (greenlet.tests.test_leaks.TestLeaks) ... expected failure
test_issue251_killing_cross_thread_leaks_list (greenlet.tests.test_leaks.TestLeaks) ... ok
test_kwarg_refs (greenlet.tests.test_leaks.TestLeaks) ... ok
test_threaded_adv_leak (greenlet.tests.test_leaks.TestLeaks) ... ok
test_threaded_leak (greenlet.tests.test_leaks.TestLeaks) ... ok
test_stack_saved (greenlet.tests.test_stack_saved.Test) ... ok
test_class (greenlet.tests.test_throw.ThrowTests) ... ok
test_kill (greenlet.tests.test_throw.ThrowTests) ... ok
test_throw_goes_to_original_parent (greenlet.tests.test_throw.ThrowTests) ... ok
test_val (greenlet.tests.test_throw.ThrowTests) ... ok
test_exception_disables_tracing (greenlet.tests.test_tracing.TracingTests) ... ok
test_greenlet_tracing (greenlet.tests.test_tracing.TracingTests) ... ok
test_version (greenlet.tests.test_version.VersionTests) ... ok
test_dead_weakref (greenlet.tests.test_weakref.WeakRefTests) ... ok
test_dealloc_weakref (greenlet.tests.test_weakref.WeakRefTests) ... ok
test_inactive_weakref (greenlet.tests.test_weakref.WeakRefTests) ... ok

----------------------------------------------------------------------
Ran 83 tests in 1.615s

OK (skipped=8, expected failures=1)

[root@9d30c71260ba greenlet]# uname -a
Linux 9d30c71260ba 4.19.190-1.lns8.loongarch64 #1 SMP Tue Jun 29 10:22:01 CST 2021 loongarch64 loongarch64 loongarch64 GNU/Linux
```