### PR TITLE
Use PyThreadState_EnterTracing()

### DIFF
--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -702,13 +702,9 @@ g_calltrace(PyObject* tracefunc, PyObject* event, PyGreenlet* origin,
     PyThreadState* tstate;
     PyErr_Fetch(&exc_type, &exc_val, &exc_tb);
     tstate = PyThreadState_GET();
-    tstate->tracing++;
-    TSTATE_USE_TRACING(tstate) = 0;
+    PyThreadState_EnterTracing(tstate);
     retval = PyObject_CallFunction(tracefunc, "O(OO)", event, origin, target);
-    tstate->tracing--;
-    TSTATE_USE_TRACING(tstate) =
-        (tstate->tracing <= 0 &&
-         ((tstate->c_tracefunc != NULL) || (tstate->c_profilefunc != NULL)));
+    PyThreadState_LeaveTracing(tstate);
     if (retval == NULL) {
         /* In case of exceptions trace function is removed */
         GET_THREAD_STATE().state().del_tracefunc();


### PR DESCRIPTION
Add PyThreadState_EnterTracing() and PyThreadState_LeaveTracing() for
Python 3.10 and older. Functions added to Python 3.11.0a2:
https://github.com/python/cpython/commit/547d26aa08aa5e4ec6e4f8a5587b30b39064a5ba

PyThreadState.cframe.use_tracing format changed again in Python
3.11.0a2 (value set to 0 or 255):
https://github.com/python/cpython/commit/bd627eb7ed08a891dd1356756feb1ce2600358e4

This change makes greenlet ready for these changes and future CPython
internal changes.