### PR TITLE
First part of making PyGreenlet opaque

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -33,6 +33,8 @@
   greenlet object was running in a thread that has exited, the repr
   now indicates that.
 
+- Main greenlets from threads that have exited are now marked as dead.
+
 1.1.2 (2021-09-29)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,10 @@
   SEH on 32-bit windows, or if you embed Python in a C++ application.
   Please contact the maintainers if you have problems in this area.
 
+- The repr of some greenlets has changed. In particular, if the
+  greenlet object was running in a thread that has exited, the repr
+  now indicates that.
+
 1.1.2 (2021-09-29)
 ==================
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -74,16 +74,6 @@ environment:
       PYTHON_VERSION: "3.5.x"
       PYTHON_EXE: python
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_ARCH: "32"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_EXE: python
-
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_EXE: python
-
     - PYTHON: "C:\\Python37"
       PYTHON_ARCH: "32"
       PYTHON_VERSION: "3.7.x"
@@ -104,6 +94,15 @@ environment:
       PYTHON_VERSION: "3.8.x"
       PYTHON_EXE: python
 
+    - PYTHON: "C:\\Python36"
+      PYTHON_ARCH: "32"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_EXE: python
+
+    - PYTHON: "C:\\Python36-x64"
+      PYTHON_ARCH: "64"
+      PYTHON_VERSION: "3.6.x"
+      PYTHON_EXE: python
 
 cache:
   - "%TMP%\\py\\"

--- a/docs/python_threads.rst
+++ b/docs/python_threads.rst
@@ -10,35 +10,61 @@ threads.
 .. doctest::
 
    >>> from greenlet import getcurrent
+   >>> from greenlet import greenlet
    >>> from threading import Thread
    >>> from threading import Event
    >>> started = Event()
    >>> switched = Event()
    >>> class T(Thread):
    ...     def run(self):
-   ...         self.glet = getcurrent()
+   ...         self.main_glet = getcurrent()
+   ...         self.child_glet = greenlet(lambda: None)
+   ...         self.child_glet.switch()
    ...         started.set()
    ...         switched.wait()
    >>> t = T()
    >>> t.start()
    >>> _ = started.wait()
-   >>> t.glet.switch()
+   >>> t.main_glet.switch()
    Traceback (most recent call last):
    ...
    greenlet.error: cannot switch to a different thread
    >>> switched.set()
    >>> t.join()
 
-Note that when a thread dies, the thread's main greenlet is not
-considered to be dead.
+Prior to greenlet 2.0, when a thread dies, the thread's main greenlet was not
+considered to be dead. This has been changed in greenlet 2.0; however,
+observing this property is still a race condition, and, on some
+platforms (those that cannot use the C runtime to detect when a thread
+exits), not guaranteed (because of the potential for uncollectable
+reference cycles to keep the Python thread state alive). In addition,
+this is considered an implementation detail and may not be true in all
+greenlet implementations.
 
 .. doctest::
 
-   >>> t.glet.dead
-   False
+   >>> t.main_glet.dead
+   True
 
 .. caution::
 
    For these reasons, it's best to not pass references to a greenlet
    running in one thread to another thread. If you do, take caution to
-   carefully manage the lifetime of the references.
+   carefully manage the lifetime of the references. If greenlets that
+   are suspended in one thread are referenced from another thread,
+   row memory and Python objects can leak.
+
+In greenlet 2.0, the error message for attempting to switch into a
+dead thread makes that fact clear; again, this is an implementation
+detail and should not be relied upon.
+
+.. doctest::
+
+   >>> t.child_glet.switch()
+   Traceback (most recent call last):
+   ...
+   greenlet.error: cannot switch to a different thread (which happens to have exited)
+   >>> t.main_glet.switch()
+   Traceback (most recent call last):
+   ...
+   greenlet.error: cannot switch to a garbage collected greenlet

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,9 @@ else:
     ext_modules = [
         Extension(
             name='greenlet._greenlet',
-            sources=[GREENLET_SRC_DIR + 'greenlet.cpp'],
+            sources=[
+                GREENLET_SRC_DIR + 'greenlet.cpp',
+            ],
             language='c++',
             extra_objects=extra_objects,
             extra_compile_args=global_compile_args + main_compile_args + cpp_compile_args,

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -273,7 +273,7 @@ public:
 
     inline bool PyExceptionMatches() const
     {
-        return PyErr_ExceptionMatches(this->p);
+        return PyErr_ExceptionMatches(this->p) > 0;
     }
 
 };

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -1596,7 +1596,7 @@ green_is_gc(BorrowedGreenlet self)
         result = 1;
     }
     // The main greenlet pointer will eventually go away after the thread dies.
-    if (self->main_greenlet && !self->main_greenlet.borrow()->thread_state) {
+    if (self->was_running_in_dead_thread()) {
         // Our thread is dead! We can never run again. Might as well
         // GC us. Note that if a tuple containing only us and other
         // immutable objects had been scanned before this, when we
@@ -2219,7 +2219,7 @@ green_repr(BorrowedGreenlet self)
          As it stands, its only useful for identifying greenlets from the same thread.
         */
         const char* state_in_thread;
-        if (!self->thread_state()) {
+        if (self->was_running_in_dead_thread()) {
             // The thread it was running in is dead!
             // This can happen, especialy at interpreter shut down.
             // It complicates debugging output becasue it may be
@@ -2236,7 +2236,7 @@ green_repr(BorrowedGreenlet self)
             "<%s object at %p (otid=%p)%s%s%s%s>",
             tp_name,
             self.borrow_o(),
-            self->main_greenlet.borrow_o(),
+            self->thread_state(),
             state_in_thread,
             self->active() ? " active" : "",
             never_started ? " pending" : " started",
@@ -2249,7 +2249,7 @@ green_repr(BorrowedGreenlet self)
             "<%s object at %p (otid=%p) %sdead>",
             tp_name,
             self.borrow_o(),
-            self->main_greenlet.borrow_o(),
+            self->thread_state(),
             self->was_running_in_dead_thread()
             ? "(thread exited) "
             : ""

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -849,7 +849,7 @@ Greenlet::g_switchstack_success() G_NOEXCEPT
 }
 
 
-typename Greenlet::switchstack_result_t
+Greenlet::switchstack_result_t
 Greenlet::g_initialstub(void* mark)
 {
     OwnedObject run;
@@ -1084,7 +1084,7 @@ Greenlet::inner_bootstrap(OwnedGreenlet& origin_greenlet, OwnedObject& run) G_NO
 }
 
 
-typename Greenlet::switchstack_result_t
+Greenlet::switchstack_result_t
 Greenlet::g_switchstack(void)
 {
     { /* save state */

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -2090,7 +2090,7 @@ green_setcontext(BorrowedGreenlet self, PyObject* nctx, void* UNUSED(context))
 static PyObject*
 green_getframe(BorrowedGreenlet self, void* UNUSED(context))
 {
-    const PythonState::OwnedFrame& top_frame = self->python_state.top_frame();
+    const PythonState::OwnedFrame& top_frame = self->top_frame();
     return top_frame.acquire_or_None();
 }
 

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -17,12 +17,16 @@ extern "C" {
 #ifndef GREENLET_MODULE
 #define main_greenlet_ptr_t void*
 #define switching_state_ptr_t void*
-// TODO: This will become a member of this type, not a pointer.
+// TODO: These will become a member of the implementation type, not a pointer.
 #define exception_state_ptr_t void*
+#define python_state_t void*
 #endif
 
 typedef struct _greenlet {
     PyObject_HEAD
+    PyObject* weakreflist;
+    PyObject* dict;
+
     char* stack_start;
     char* stack_stop;
     char* stack_copy;
@@ -32,19 +36,13 @@ typedef struct _greenlet {
     /* strong reference, set when the greenlet begins to run. */
     /* Used to be called run_info */
     main_greenlet_ptr_t main_greenlet_s;
-    struct _frame* top_frame; /* weak reference (suspended) or NULL (running) */
-    int recursion_depth;
-    PyObject* weakreflist;
+
+
+
     // This is only temporary!
     exception_state_ptr_t exception_state;
+    python_state_t python_state;
 
-    PyObject* dict;
-#if PY_VERSION_HEX >= 0x030700A3
-    PyObject* context;
-#endif
-#if PY_VERSION_HEX >= 0x30A00B1
-    CFrame* cframe;
-#endif
     // XXX: Adding this field is a breaker, unless we can
     // get rid of the run_info field completely.
     // If we can get it down to just one pointer, we could
@@ -58,7 +56,7 @@ typedef struct _greenlet {
     switching_state_ptr_t switching_state;
 } PyGreenlet;
 
-#define PyGreenlet_Check(op) PyObject_TypeCheck(op, &PyGreenlet_Type)
+#define PyGreenlet_Check(op) (op && PyObject_TypeCheck(op, &PyGreenlet_Type))
 #define PyGreenlet_MAIN(op) (((PyGreenlet*)(op))->stack_stop == (char*)-1)
 #define PyGreenlet_STARTED(op) (((PyGreenlet*)(op))->stack_stop != NULL)
 #define PyGreenlet_ACTIVE(op) (((PyGreenlet*)(op))->stack_start != NULL)

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -15,43 +15,14 @@ extern "C" {
 #define GREENLET_VERSION "1.0.0"
 
 #ifndef GREENLET_MODULE
-#define main_greenlet_ptr_t void*
-#define switching_state_ptr_t void*
-// TODO: These will become a member of the implementation type, not a pointer.
-#define exception_state_ptr_t void*
-#define python_state_t void*
-#define stack_state_t void*
+#define implementation_ptr_t void*
 #endif
 
 typedef struct _greenlet {
     PyObject_HEAD
     PyObject* weakreflist;
     PyObject* dict;
-
-
-    struct _greenlet* parent;
-    /* strong reference, set when the greenlet begins to run. */
-    /* Used to be called run_info */
-    main_greenlet_ptr_t main_greenlet_s;
-
-
-
-    // This is only temporary!
-    exception_state_ptr_t exception_state;
-    python_state_t python_state;
-    stack_state_t stack_state;
-
-    // XXX: Adding this field is a breaker, unless we can
-    // get rid of the run_info field completely.
-    // If we can get it down to just one pointer, we could
-    // re-purpose an existing field; actually, we could already do that by
-    // making ``run_info``, oko ``main_greenlet_s`` a tuple or list.
-    // If we do go ahead and add this field, we should take out all the
-    // CPython-version specific stuff and move those to their own structure
-    // that we access via a pointer so that we can evolve this object in the
-    // future without introducing ABI issues.
-    PyObject* run_callable;
-    switching_state_ptr_t switching_state;
+    implementation_ptr_t pimpl;
 } PyGreenlet;
 
 #define PyGreenlet_Check(op) (op && PyObject_TypeCheck(op, &PyGreenlet_Type))

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -17,6 +17,8 @@ extern "C" {
 #ifndef GREENLET_MODULE
 #define main_greenlet_ptr_t void*
 #define switching_state_ptr_t void*
+// TODO: This will become a member of this type, not a pointer.
+#define exception_state_ptr_t void*
 #endif
 
 typedef struct _greenlet {
@@ -33,14 +35,9 @@ typedef struct _greenlet {
     struct _frame* top_frame; /* weak reference (suspended) or NULL (running) */
     int recursion_depth;
     PyObject* weakreflist;
-#if PY_VERSION_HEX >= 0x030700A3
-    _PyErr_StackItem* exc_info;
-    _PyErr_StackItem exc_state;
-#else
-    PyObject* exc_type;
-    PyObject* exc_value;
-    PyObject* exc_traceback;
-#endif
+    // This is only temporary!
+    exception_state_ptr_t exception_state;
+
     PyObject* dict;
 #if PY_VERSION_HEX >= 0x030700A3
     PyObject* context;

--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -1,0 +1,57 @@
+#ifndef GREENLET_ALLOCATOR_HPP
+#define GREENLET_ALLOCATOR_HPP
+
+#include <Python.h>
+#include <memory>
+#include "greenlet_compiler_compat.hpp"
+
+
+namespace greenlet
+{
+    // This allocator is stateless; all instances are identical.
+    // It can *ONLY* be used when we're sure we're holding the GIL
+    // (Python's allocators require the GIL).
+    template <class T>
+    struct PythonAllocator : public std::allocator<T> {
+
+        PythonAllocator(const PythonAllocator& UNUSED(other))
+            : std::allocator<T>()
+        {
+        }
+
+        PythonAllocator(const std::allocator<T> other)
+            : std::allocator<T>(other)
+        {}
+
+        template <class U>
+        PythonAllocator(const std::allocator<U>& other)
+            : std::allocator<T>(other)
+        {
+        }
+
+        PythonAllocator() : std::allocator<T>() {}
+
+        T* allocate(size_t number_objects, const void* UNUSED(hint)=0)
+        {
+            void* p;
+            if (number_objects == 1)
+                p = PyObject_Malloc(sizeof(T));
+            else
+                p = PyMem_Malloc(sizeof(T) * number_objects);
+            return static_cast<T*>(p);
+        }
+
+        void deallocate(T* t, size_t n)
+        {
+            void* p = t;
+            if (n == 1) {
+                PyObject_Free(p);
+            }
+            else
+                PyMem_Free(p);
+        }
+
+    };
+}
+
+#endif

--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -4,7 +4,7 @@
 #include <Python.h>
 #include <memory>
 #include "greenlet_compiler_compat.hpp"
-
+// #include <iostream>
 
 namespace greenlet
 {
@@ -33,6 +33,13 @@ namespace greenlet
 
         T* allocate(size_t number_objects, const void* UNUSED(hint)=0)
         {
+            // using std::cerr;
+            // using std::endl;
+
+            // cerr << "Allocating " << number_objects
+            //      << " at " << UNUSED_hint
+            //      << " from " << typeid(this).name()
+            //      << endl;
             void* p;
             if (number_objects == 1)
                 p = PyObject_Malloc(sizeof(T));
@@ -43,6 +50,13 @@ namespace greenlet
 
         void deallocate(T* t, size_t n)
         {
+            // using std::cerr;
+            // using std::endl;
+            // cerr << "Deallocating " << n
+            //      << " at " << t
+            //      << " of " << typeid(t).name()
+            //      << " from " << typeid(this).name()
+            //      << endl;
             void* p = t;
             if (n == 1) {
                 PyObject_Free(p);

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -35,7 +35,14 @@ typedef unsigned int uint32_t;
 #define G_HAS_METHOD_DELETE 1
 #define G_EXPLICIT_OP explicit
 #define G_NOEXCEPT noexcept
-#define G_FP_TMPL_STATIC static
+# if defined(__clang__)
+#  define G_FP_TMPL_STATIC static
+# else
+// GCC has no problem allowing static function pointers, but emits
+// tons of warnings about "whose type uses the anonymous namespace [-Wsubobject-linkage]"
+#  define G_FP_TMPL_STATIC
+# endif
+
 #endif
 
 #if G_HAS_METHOD_DELETE == 1

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -34,19 +34,23 @@ typedef unsigned int uint32_t;
 #endif
 
 #if G_HAS_METHOD_DELETE == 1
-#    define G_NO_COPIES_OF_CLS(Cls) public:     \
+#    define G_NO_COPIES_OF_CLS(Cls) private:     \
     Cls(const Cls& other) = delete; \
     Cls& operator=(const Cls& other) = delete
-#    define G_NO_ASSIGNMENT_OF_CLS(Cls) public:  \
+
+#    define G_NO_ASSIGNMENT_OF_CLS(Cls) private:  \
     Cls& operator=(const Cls& other) = delete
-#    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) public: \
+
+#    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) private: \
     Cls(const Cls& other) = delete;
 #else
 #    define G_NO_COPIES_OF_CLS(Cls) private: \
     Cls(const Cls& other); \
     Cls& operator=(const Cls& other)
+
 #    define G_NO_ASSIGNMENT_OF_CLS(Cls) private: \
         Cls& operator=(const Cls& other)
+
 #    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) private: \
     Cls(const Cls& other);
 #endif

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -7,7 +7,7 @@
  *
  */
 
-#define UNUSED(expr) do { (void)(expr); } while (0)
+
 /* The compiler used for Python 2.7 on Windows doesn't include
    either stdint.h or cstdint.h. Nor does it understand nullptr or have
    std::shared_ptr. = delete, etc Sigh. */
@@ -68,11 +68,13 @@ typedef unsigned int uint32_t;
 #    define GREENLET_NOINLINE_SUPPORTED
 #    define GREENLET_NOINLINE(name) __attribute__((noinline)) name
 #    define GREENLET_NOINLINE_P(rtype, name) rtype __attribute__((noinline)) name
+#    define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 #elif defined(_MSC_VER)
 /* We used to check for  && (_MSC_VER >= 1300) but that's also out of date. */
 #    define GREENLET_NOINLINE_SUPPORTED
 #    define GREENLET_NOINLINE(name) __declspec(noinline) name
 #    define GREENLET_NOINLINE_P(rtype, name) __declspec(noinline) rtype name
+#    define UNUSED(x) UNUSED_ ## x
 #endif
 
 

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -39,12 +39,16 @@ typedef unsigned int uint32_t;
     Cls& operator=(const Cls& other) = delete
 #    define G_NO_ASSIGNMENT_OF_CLS(Cls) public:  \
     Cls& operator=(const Cls& other) = delete
+#    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) public: \
+    Cls(const Cls& other) = delete;
 #else
 #    define G_NO_COPIES_OF_CLS(Cls) private: \
     Cls(const Cls& other); \
     Cls& operator=(const Cls& other)
 #    define G_NO_ASSIGNMENT_OF_CLS(Cls) private: \
         Cls& operator=(const Cls& other)
+#    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) private: \
+    Cls(const Cls& other);
 #endif
 
 // CAUTION: MSVC is stupidly picky:

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -25,12 +25,17 @@ typedef unsigned int uint32_t;
 // methods.
 #define G_EXPLICIT_OP
 #define G_NOEXCEPT throw()
+// This version doesn't support "objects with internal linkage"
+// in non-type template arguments. Translation: function pointer
+// template arguments cannot be for static functions.
+#define G_FP_TMPL_STATIC
 #else
 // Newer, reasonable compilers implementing C++11 or so.
 #include <cstdint>
 #define G_HAS_METHOD_DELETE 1
 #define G_EXPLICIT_OP explicit
 #define G_NOEXCEPT noexcept
+#define G_FP_TMPL_STATIC static
 #endif
 
 #if G_HAS_METHOD_DELETE == 1

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -8,11 +8,34 @@
 
 #include "Python.h"
 
+// These enable writing template functions or classes specialized
+// based on the Python version. Write both versions of the function,
+// one with the WHEN version, one with the WHEN_NOT version.
+// Instantiate the template using the G_IS_PY37 macro.
+// NOTE: The compiler still sees (and type checks) both versions, apparently, even when
+// not instantiated? I didn't think that was how expansion worked, if
+// one template is never needed.
+struct GREENLET_WHEN_PY37
+{
+    typedef GREENLET_WHEN_PY37* Yes;
+    using IsIt = Yes;
+};
+
+struct GREENLET_WHEN_NOT_PY37
+{
+    typedef GREENLET_WHEN_NOT_PY37* No;
+    using IsIt = No;
+};
+
+
 #if PY_VERSION_HEX >= 0x030700A3
 #    define GREENLET_PY37 1
+typedef GREENLET_WHEN_PY37 G_IS_PY37;
 #else
 #    define GREENLET_PY37 0
+typedef GREENLET_WHEN_NOT_PY37 G_IS_PY37;
 #endif
+
 
 #if PY_VERSION_HEX >= 0x30A00B1
 /*

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -18,13 +18,15 @@
 struct GREENLET_WHEN_PY37
 {
     typedef GREENLET_WHEN_PY37* Yes;
-    using IsIt = Yes;
+    // We really just want an alias, `using Yes = IsIt`,
+    // but old MSVC for Py27 doesn't support that.
+    typedef GREENLET_WHEN_PY37* IsIt;
 };
 
 struct GREENLET_WHEN_NOT_PY37
 {
     typedef GREENLET_WHEN_NOT_PY37* No;
-    using IsIt = No;
+    typedef GREENLET_WHEN_NOT_PY37* IsIt;
 };
 
 

--- a/src/greenlet/greenlet_exceptions.hpp
+++ b/src/greenlet/greenlet_exceptions.hpp
@@ -11,17 +11,6 @@
 
 namespace greenlet {
 
-    class TypeError : public std::runtime_error
-    {
-    public:
-        TypeError(const char* const what) : std::runtime_error(what)
-        {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, what);
-            }
-        }
-    };
-
     class PyErrOccurred : public std::runtime_error
     {
     public:
@@ -34,6 +23,33 @@ namespace greenlet {
             : std::runtime_error(msg)
         {
             PyErr_SetString(exc_kind, msg);
+        }
+    };
+
+    class TypeError : public PyErrOccurred
+    {
+    public:
+        TypeError(const char* const what)
+            : PyErrOccurred(PyExc_TypeError, what)
+        {
+        }
+    };
+
+    class ValueError : public PyErrOccurred
+    {
+    public:
+        ValueError(const char* const what)
+            : PyErrOccurred(PyExc_ValueError, what)
+        {
+        }
+    };
+
+    class AttributeError : public PyErrOccurred
+    {
+    public:
+        AttributeError(const char* const what)
+            : PyErrOccurred(PyExc_AttributeError, what)
+        {
         }
     };
 

--- a/src/greenlet/greenlet_exceptions.hpp
+++ b/src/greenlet/greenlet_exceptions.hpp
@@ -1,0 +1,77 @@
+#ifndef GREENLET_EXCEPTIONS_HPP
+#define GREENLET_EXCEPTIONS_HPP
+
+#include <Python.h>
+#include <stdexcept>
+
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wunused-function"
+#endif
+
+namespace greenlet {
+
+    class TypeError : public std::runtime_error
+    {
+    public:
+        TypeError(const char* const what) : std::runtime_error(what)
+        {
+            if (!PyErr_Occurred()) {
+                PyErr_SetString(PyExc_TypeError, what);
+            }
+        }
+    };
+
+    class PyErrOccurred : public std::runtime_error
+    {
+    public:
+        PyErrOccurred() : std::runtime_error("")
+        {
+            assert(PyErr_Occurred());
+        }
+
+        PyErrOccurred(PyObject* exc_kind, const char* const msg)
+            : std::runtime_error(msg)
+        {
+            PyErr_SetString(exc_kind, msg);
+        }
+    };
+
+    /**
+     * Calls `Py_FatalError` when constructed, so you can't actually
+     * throw this. It just makes static analysis easier.
+     */
+    class PyFatalError : public std::runtime_error
+    {
+    public:
+        PyFatalError(const char* const msg)
+            : std::runtime_error(msg)
+        {
+            Py_FatalError(msg);
+        }
+    };
+
+    static inline PyObject*
+    Require(PyObject* p)
+    {
+        if (!p) {
+            throw PyErrOccurred();
+        }
+        return p;
+    };
+
+    static inline void
+    Require(const int retval)
+    {
+        if (retval < 0) {
+            throw PyErrOccurred();
+        }
+    };
+
+
+};
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
+
+#endif

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -330,14 +330,20 @@ namespace greenlet
          */
         void murder_in_place();
 
-        void deallocing_greenlet_in_thread(const ThreadState& state);
+        // Called when some thread wants to deallocate a greenlet
+        // object.
+        // The thread may or may not be the same thread the greenlet
+        // was running in.
+        // The thread state will be null if the thread the greenlet
+        // was running in was known to have exited.
+        void deallocing_greenlet_in_thread(const ThreadState* current_state);
 
         // TODO: Figure out how to make these non-public.
         inline void slp_restore_state() G_NOEXCEPT;
         inline int slp_save_state(char *const stackref) G_NOEXCEPT;
 
         inline bool is_currently_running_in_some_thread() const;
-        inline bool belongs_to_thread(const ThreadState& state) const;
+        inline bool belongs_to_thread(const ThreadState* state) const;
         inline bool started() const
         {
             return this->stack_state.started();
@@ -387,7 +393,10 @@ namespace greenlet
             ParentIsCurrentGuard(Greenlet* p, const ThreadState& thread_state);
             ~ParentIsCurrentGuard();
         };
-
+        // Return the thread state that the greenlet is running in, or
+        // null if the greenlet is not running or the thread is known
+        // to have exited.
+        inline ThreadState* thread_state() const G_NOEXCEPT;
     protected:
         // The functions that must not be inlined are declared virtual.
         // We also mark them as protected, not private, so that the
@@ -443,7 +452,7 @@ namespace greenlet
         virtual switchstack_result_t g_initialstub(void* mark);
 
     private:
-        inline ThreadState* thread_state() G_NOEXCEPT;
+
         void inner_bootstrap(OwnedGreenlet& origin_greenlet, OwnedObject& run) G_NOEXCEPT;
         /**
            Perform a stack switch into this greenlet.

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -67,6 +67,11 @@ namespace greenlet
             return this->_context;
         }
 
+        inline void tp_clear()
+        {
+            this->_context.CLEAR();
+        }
+
         template<typename T>
         inline static PyObject* context(T* tstate)
         {
@@ -95,6 +100,8 @@ namespace greenlet
         {
             throw AttributeError("no context");
         }
+
+        inline void tp_clear(){};
 
         template<typename T>
         inline static PyObject* context(T* UNUSED(tstate))
@@ -732,9 +739,7 @@ int PythonState::tp_traverse(visitproc visit, void* arg, bool own_top_frame) G_N
 
 void PythonState::tp_clear(bool own_top_frame) G_NOEXCEPT
 {
-#if GREENLET_PY37
-    this->_context.CLEAR();
-#endif
+    PythonStateContext::tp_clear();
     // If we get here owning a frame,
     // we got dealloc'd without being finished. We may or may not be
     // in the same thread.

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -289,8 +289,9 @@ namespace greenlet
         ExceptionState exception_state;
         SwitchingArgs switch_args;
         OwnedGreenlet _parent;
-    public:
         PythonState python_state;
+    public:
+
         OwnedObject run_callable;
 
 
@@ -353,6 +354,11 @@ namespace greenlet
         }
 
         inline void parent(const refs::BorrowedObject new_parent);
+
+        inline const PythonState::OwnedFrame& top_frame()
+        {
+            return this->python_state.top_frame();
+        }
 
         int tp_traverse(visitproc visit, void* arg);
         int tp_clear();

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -290,10 +290,7 @@ namespace greenlet
         SwitchingArgs switch_args;
         OwnedGreenlet _parent;
         PythonState python_state;
-    public:
-
-        OwnedObject run_callable;
-
+        OwnedObject _run_callable;
 
     public: // protected
         StackState stack_state;
@@ -359,6 +356,16 @@ namespace greenlet
         {
             return this->python_state.top_frame();
         }
+
+        inline const OwnedObject& run() const
+        {
+            if (this->started() || !this->_run_callable) {
+                throw AttributeError("run");
+            }
+            return this->_run_callable;
+        }
+
+        inline void run(const refs::BorrowedObject nrun);
 
         int tp_traverse(visitproc visit, void* arg);
         int tp_clear();

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -298,13 +298,13 @@ namespace greenlet
         OwnedObject _run_callable;
         StackState stack_state;
     protected:
-        // The main greenlet subclass accesses this once or twice.
+        // The main greenlet subclass accesses `self` and `main_greenlet` once or twice.
         // But see the comment where it does. This is probably
         // factored wrong.
         BorrowedGreenlet self;
-        Greenlet(PyGreenlet* p, BorrowedGreenlet the_parent, const StackState& initial_state);
-    public:
         OwnedMainGreenlet main_greenlet;
+        Greenlet(PyGreenlet* p, BorrowedGreenlet the_parent, const StackState& initial_state);
+
     public:
         static void* operator new(size_t UNUSED(count));
         static void operator delete(void* ptr);

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -1,0 +1,138 @@
+#ifndef GREENLET_GREENLET_HPP
+#define GREENLET_GREENLET_HPP
+/*
+ * Declarations of the core data structures.
+*/
+
+#include <Python.h>
+//#include "greenlet_internal.hpp"
+#include "greenlet_compiler_compat.hpp"
+#include "greenlet_refs.hpp"
+
+using greenlet::refs::OwnedObject;
+
+namespace greenlet
+{
+    class ExceptionState
+    {
+    private:
+        G_NO_COPIES_OF_CLS(ExceptionState);
+
+#if PY_VERSION_HEX >= 0x030700A3
+        // Even though these are borrowed objects, we actually own
+        // them, when they're not null.
+        // XXX: Express that in the API.
+    private:
+        _PyErr_StackItem* exc_info;
+        _PyErr_StackItem exc_state;
+#else
+        OwnedObject exc_type;
+        OwnedObject exc_value;
+        OwnedObject exc_traceback;
+#endif
+    public:
+        ExceptionState();
+        void operator<<(const PyThreadState *const tstate) G_NOEXCEPT;
+        void operator>>(PyThreadState* tstate) G_NOEXCEPT;
+        void clear() G_NOEXCEPT;
+
+        int tp_traverse(visitproc visit, void* arg) G_NOEXCEPT;
+        void tp_clear() G_NOEXCEPT;
+    };
+
+    void operator<<(const PyThreadState *const tstate, ExceptionState& exc);
+};
+
+using greenlet::ExceptionState;
+
+ExceptionState::ExceptionState()
+{
+    this->clear();
+}
+
+#if PY_VERSION_HEX >= 0x030700A3
+// ******** Python 3.7 and above *********
+void ExceptionState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+{
+    this->exc_info = tstate->exc_info;
+    this->exc_state = tstate->exc_state;
+}
+
+void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+{
+    tstate->exc_state = this->exc_state;
+    tstate->exc_info =
+        this->exc_info ? this->exc_info : &tstate->exc_state;
+    this->clear();
+}
+
+void ExceptionState::clear() G_NOEXCEPT
+{
+    this->exc_info = nullptr;
+    this->exc_state.exc_type = nullptr;
+    this->exc_state.exc_value = nullptr;
+    this->exc_state.exc_traceback = nullptr;
+    this->exc_state.previous_item = nullptr;
+}
+
+int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
+{
+    Py_VISIT(this->exc_state.exc_type);
+    Py_VISIT(this->exc_state.exc_value);
+    Py_VISIT(this->exc_state.exc_traceback);
+    return 0;
+}
+
+void ExceptionState::tp_clear() G_NOEXCEPT
+{
+    Py_CLEAR(this->exc_state.exc_type);
+    Py_CLEAR(this->exc_state.exc_value);
+    Py_CLEAR(this->exc_state.exc_traceback);
+}
+#else
+// ********** Python 3.6 and below ********
+void ExceptionState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+{
+    this->exc_type.steal(tstate->exc_type);
+    this->exc_value.steal(tstate->exc_value);
+    this->exc_traceback.steal(tstate->exc_traceback);
+}
+
+void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+{
+    tstate->exc_type <<= this->exc_type;
+    tstate->exc_value <<= this->exc_value;
+    tstate->exc_traceback <<= this->exc_traceback;
+    this->clear();
+}
+
+void ExceptionState::clear() G_NOEXCEPT
+{
+    this->exc_type = nullptr;
+    this->exc_value = nullptr;
+    this->exc_traceback = nullptr;
+}
+
+int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
+{
+    Py_VISIT(this->exc_type.borrow());
+    Py_VISIT(this->exc_value.borrow());
+    Py_VISIT(this->exc_traceback.borrow());
+    return 0;
+}
+
+void ExceptionState::tp_clear() G_NOEXCEPT
+{
+    this->exc_type.CLEAR();
+    this->exc_value.CLEAR();
+    this->exc_traceback.CLEAR();
+}
+#endif
+
+void greenlet::operator<<(const PyThreadState *const tstate, ExceptionState& exc)
+{
+    exc.operator<<(tstate);
+}
+
+
+#endif

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -8,6 +8,7 @@
 //#include "greenlet_internal.hpp"
 #include "greenlet_compiler_compat.hpp"
 #include "greenlet_refs.hpp"
+#include "greenlet_cpython_compat.hpp"
 
 using greenlet::refs::OwnedObject;
 
@@ -40,8 +41,50 @@ namespace greenlet
         void tp_clear() G_NOEXCEPT;
     };
 
-    void operator<<(const PyThreadState *const tstate, ExceptionState& exc);
+    template<typename T>
+    void operator<<(const PyThreadState *const tstate, T& exc);
+
+    class PythonState
+    {
+    private:
+        G_NO_COPIES_OF_CLS(PythonState);
+        /* weak reference (suspended) or NULL (running) */
+        struct _frame* _top_frame;
+
+#if GREENLET_PY37
+        OwnedObject _context;
+#endif
+#if  GREENLET_USE_CFRAME
+        CFrame* cframe;
+        int use_tracing;
+#endif
+        int recursion_depth;
+    public:
+        PythonState();
+        bool has_top_frame() const G_NOEXCEPT;
+        PyObject* top_frame() const G_NOEXCEPT;
+#if GREENLET_PY37
+        OwnedObject& context();
+#endif
+        void operator<<(const PyThreadState *const tstate) G_NOEXCEPT;
+        void operator>>(PyThreadState* tstate) G_NOEXCEPT;
+        void clear() G_NOEXCEPT;
+
+        int tp_traverse(visitproc visit, void* arg, bool visit_top_frame) G_NOEXCEPT;
+        void tp_clear(bool own_top_frame) G_NOEXCEPT;
+        void set_initial_state(const PyThreadState* const tstate) G_NOEXCEPT;
+#if GREENLET_USE_CFRAME
+        void set_new_cframe(CFrame& frame) G_NOEXCEPT;
+#endif
+        void will_switch_from(PyThreadState *const origin_tstate) G_NOEXCEPT;
+    };
 };
+
+template<typename T>
+void greenlet::operator<<(const PyThreadState *const tstate, T& exc)
+{
+    exc.operator<<(tstate);
+}
 
 using greenlet::ExceptionState;
 
@@ -129,10 +172,184 @@ void ExceptionState::tp_clear() G_NOEXCEPT
 }
 #endif
 
-void greenlet::operator<<(const PyThreadState *const tstate, ExceptionState& exc)
+
+using greenlet::PythonState;
+
+PythonState::PythonState()
 {
-    exc.operator<<(tstate);
+#if GREENLET_USE_CFRAME
+    /*
+      The PyThreadState->cframe pointer usually points to memory on
+      the stack, alloceted in a call into PyEval_EvalFrameDefault.
+
+      Initially, before any evaluation begins, it points to the
+      initial PyThreadState object's ``root_cframe`` object, which is
+      statically allocated for the lifetime of the thread.
+
+      A greenlet can last for longer than a call to
+      PyEval_EvalFrameDefault, so we can't set its ``cframe`` pointer
+      to be the current ``PyThreadState->cframe``; nor could we use
+      one from the greenlet parent for the same reason. Yet a further
+      no: we can't allocate one scoped to the greenlet and then
+      destroy it when the greenlet is deallocated, because inside the
+      interpreter the CFrame objects form a linked list, and that too
+      can result in accessing memory beyond its dynamic lifetime (if
+      the greenlet doesn't actually finish before it dies, its entry
+      could still be in the list).
+
+      Using the ``root_cframe`` is problematic, though, because its
+      members are never modified by the interpreter and are set to 0,
+      meaning that its ``use_tracing`` flag is never updated. We don't
+      want to modify that value in the ``root_cframe`` ourself: it
+      *shouldn't* matter much because we should probably never get
+      back to the point where that's the only cframe on the stack;
+      even if it did matter, the major consequence of an incorrect
+      value for ``use_tracing`` is that if its true the interpreter
+      does some extra work --- however, it's just good code hygiene.
+
+      Our solution: before a greenlet runs, after its initial
+      creation, it uses the ``root_cframe`` just to have something to
+      put there. However, once the greenlet is actually switched to
+      for the first time, ``g_initialstub`` (which doesn't actually
+      "return" while the greenlet is running) stores a new CFrame on
+      its local stack, and copies the appropriate values from the
+      currently running CFrame; this is then made the CFrame for the
+      newly-minted greenlet. ``g_initialstub`` then proceeds to call
+      ``glet.run()``, which results in ``PyEval_...`` adding the
+      CFrame to the list. Switches continue as normal. Finally, when
+      the greenlet finishes, the call to ``glet.run()`` returns and
+      the CFrame is taken out of the linked list and the stack value
+      is now unused and free to expire.
+
+      XXX: I think we can do better. If we're deallocing in the same
+      thread, can't we traverse the list and unlink our frame?
+      Can we just keep a reference to the thread state in case we
+      dealloc in another thread? (Is that even possible if we're still
+      running and haven't returned from g_initialstub?)
+    */
+    this->cframe = &PyThreadState_GET()->root_cframe;
+#endif
 }
 
+void PythonState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+{
+    this->recursion_depth = tstate->recursion_depth;
+    this->_top_frame = tstate->frame;
+#if GREENLET_PY37
+    this->_context.steal(tstate->context);
+#endif
+#if GREENLET_USE_CFRAME
+    /*
+      IMPORTANT: ``cframe`` is a pointer into the STACK. Thus, because
+      the call to ``slp_switch()`` changes the contents of the stack,
+      you cannot read from ``ts_current->cframe`` after that call and
+      necessarily get the same values you get from reading it here.
+      Anything you need to restore from now to then must be saved in a
+      global/threadlocal variable (because we can't use stack
+      variables here either). For things that need to persist across
+      the switch, use `will_switch_from`.
+    */
+    this->cframe = tstate->cframe;
+    this->use_tracing = tstate->cframe->use_tracing;
+#endif
+}
+
+void PythonState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+{
+    tstate->recursion_depth = this->recursion_depth;
+    tstate->frame = this->_top_frame;
+    this->_top_frame = nullptr;
+
+#if GREENLET_PY37
+    tstate->context = this->_context.relinquish_ownership();
+    this->_context = nullptr;
+    /* Incrementing this value invalidates the contextvars cache,
+       which would otherwise remain valid across switches */
+    tstate->context_ver++;
+#endif
+#if GREENLET_USE_CFRAME
+    tstate->cframe = this->cframe;
+    /*
+      If we were tracing, we need to keep tracing.
+      There should never be the possibility of hitting the
+      root_cframe here. See note above about why we can't
+      just copy this from ``origin->cframe->use_tracing``.
+    */
+    tstate->cframe->use_tracing = this->use_tracing;
+#endif
+}
+
+void PythonState::will_switch_from(PyThreadState *const origin_tstate) G_NOEXCEPT
+{
+#if GREENLET_USE_CFRAME
+    // The weird thing is, we don't actually save this for an
+    // effect on the current greenlet, it's saved for an
+    // effect on the target greenlet. That is, we want
+    // continuity of this setting across the greenlet switch.
+    this->use_tracing = origin_tstate->cframe->use_tracing;
+#endif
+}
+
+void PythonState::set_initial_state(const PyThreadState* const tstate) G_NOEXCEPT
+{
+    this->_top_frame = nullptr;
+    this->recursion_depth = tstate->recursion_depth;
+}
+// TODO: Better state management about when we own the top frame.
+int PythonState::tp_traverse(visitproc visit, void* arg, bool own_top_frame) G_NOEXCEPT
+{
+#if GREENLET_PY37
+    Py_VISIT(this->_context.borrow());
+#endif
+    if (own_top_frame) {
+        Py_VISIT(this->_top_frame);
+    }
+    return 0;
+}
+
+void PythonState::tp_clear(bool own_top_frame) G_NOEXCEPT
+{
+#if GREENLET_PY37
+    this->_context.CLEAR();
+#endif
+    // If we get here owning a frame,
+    // we got dealloc'd without being finished. We may or may not be
+    // in the same thread.
+    if (own_top_frame) {
+        Py_CLEAR(this->_top_frame);
+    }
+}
+
+#if GREENLET_USE_CFRAME
+void PythonState::set_new_cframe(CFrame& frame) G_NOEXCEPT
+{
+    frame = *PyThreadState_GET()->cframe;
+    /* Make the target greenlet refer to the stack value. */
+    this->cframe = &frame;
+    /*
+      And restore the link to the previous frame so this one gets
+      unliked appropriately.
+    */
+    this->cframe->previous = &PyThreadState_GET()->root_cframe;
+}
+#endif
+
+bool PythonState::has_top_frame() const G_NOEXCEPT
+{
+    return this->_top_frame != nullptr;
+}
+
+PyObject* PythonState::top_frame() const G_NOEXCEPT
+{
+    return reinterpret_cast<PyObject*>(this->_top_frame);
+}
+
+#if GREENLET_PY37
+OwnedObject& PythonState::context()
+{
+    return this->_context;
+}
+
+#endif
 
 #endif

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -284,7 +284,6 @@ namespace greenlet
         G_NO_COPIES_OF_CLS(Greenlet);
     private:
         friend class ThreadState; // XXX: Work to remove this.
-        friend int slp_switch(void);
 
         BorrowedGreenlet self;
         ExceptionState exception_state;

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -288,10 +288,11 @@ namespace greenlet
         BorrowedGreenlet self;
         ExceptionState exception_state;
         SwitchingArgs switch_args;
+        OwnedGreenlet _parent;
     public:
         PythonState python_state;
         OwnedObject run_callable;
-        OwnedGreenlet parent;
+
 
     public: // protected
         StackState stack_state;
@@ -306,25 +307,8 @@ namespace greenlet
         template <typename IsPy37> // maybe we can use a value here?
         const OwnedObject context(const typename IsPy37::IsIt=nullptr) const;
 
-        template<typename IsPy37>
-        class ContextSetter
-        {
-        private:
-            friend class Greenlet;
-            Greenlet* p;
-            ContextSetter(Greenlet* it) : p(it)
-            {}
-
-            G_NO_ASSIGNMENT_OF_CLS(ContextSetter);
-        public:
-            void operator=(refs::BorrowedObject new_context);
-        };
-
         template <typename IsPy37>
-        inline ContextSetter<IsPy37> context(bool, typename IsPy37::IsIt=nullptr)
-        {
-            return ContextSetter<IsPy37>(this);
-        }
+        inline void context(refs::BorrowedObject new_context, typename IsPy37::IsIt=nullptr);
 
         inline SwitchingArgs& args()
         {
@@ -363,7 +347,12 @@ namespace greenlet
         }
         virtual refs::BorrowedMainGreenlet find_main_greenlet_in_lineage() const;
 
-        inline void set_parent(refs::BorrowedObject& new_parent);
+        inline const OwnedGreenlet parent() const
+        {
+            return this->_parent;
+        }
+
+        inline void parent(const refs::BorrowedObject new_parent);
 
         int tp_traverse(visitproc visit, void* arg);
         int tp_clear();

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -28,6 +28,7 @@ class SwitchingState;
 #define main_greenlet_ptr_t struct _PyMainGreenlet*
 #define switching_state_ptr_t SwitchingState*
 #define exception_state_ptr_t greenlet::ExceptionState
+#define python_state_t greenlet::PythonState
 
 
 #include "greenlet.h"

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -29,9 +29,19 @@ class SwitchingState;
 #define switching_state_ptr_t SwitchingState*
 #define exception_state_ptr_t greenlet::ExceptionState
 #define python_state_t greenlet::PythonState
+#define stack_state_t greenlet::StackState
 
 
 #include "greenlet.h"
+
+#undef PyGreenlet_MAIN
+#undef PyGreenlet_STARTED
+#undef PyGreenlet_ACTIVE
+
+#define PyGreenlet_MAIN(op) (((PyGreenlet*)(op))->stack_state.main())
+#define PyGreenlet_STARTED(op) (((PyGreenlet*)(op))->stack_state.started())
+#define PyGreenlet_ACTIVE(op) (((PyGreenlet*)(op))->stack_state.active())
+
 
 #include <vector>
 #include <memory>

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -32,7 +32,6 @@ namespace greenlet {
 
 };
 struct _PyMainGreenlet;
-class SwitchingState;
 
 #define implementation_ptr_t greenlet::Greenlet*
 
@@ -86,7 +85,7 @@ static inline bool PyGreenlet_ACTIVE(const PyGreenlet* g)
 }
 
 template<>
-inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator Greenlet*() const G_NOEXCEPT
+inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator greenlet::Greenlet*() const G_NOEXCEPT
 {
     if (!this->p) {
         return nullptr;
@@ -94,7 +93,7 @@ inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator Greenlet*() cons
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
 
-#include <vector>
+
 #include <memory>
 #include <stdexcept>
 

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -19,6 +19,8 @@
 #include "greenlet_greenlet.hpp"
 #include "greenlet_allocator.hpp"
 
+#include <vector>
+
 #define GREENLET_MODULE
 struct _greenlet;
 typedef struct _greenlet PyGreenlet;

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -93,6 +93,17 @@ inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator greenlet::Greenl
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
 
+template <typename T>
+inline Greenlet* greenlet::refs::_OwnedGreenlet<T>::operator->() const G_NOEXCEPT
+{
+    return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
+}
+
+template <typename T>
+inline Greenlet* greenlet::refs::_BorrowedGreenlet<T>::operator->() const G_NOEXCEPT
+{
+    return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
+}
 
 #include <memory>
 #include <stdexcept>

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -83,10 +83,9 @@ namespace greenlet
     template <class T>
     struct PythonAllocator : public std::allocator<T> {
 
-        PythonAllocator(const PythonAllocator& other)
+        PythonAllocator(const PythonAllocator& UNUSED(other))
             : std::allocator<T>()
         {
-            UNUSED(other);
         }
 
         PythonAllocator(const std::allocator<T> other)
@@ -101,9 +100,8 @@ namespace greenlet
 
         PythonAllocator() : std::allocator<T>() {}
 
-        T* allocate(size_t number_objects, const void* hint=0)
+        T* allocate(size_t number_objects, const void* UNUSED(hint)=0)
         {
-            UNUSED(hint);
             void* p;
             if (number_objects == 1)
                 p = PyObject_Malloc(sizeof(T));

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -41,7 +41,7 @@ struct _PyMainGreenlet;
 
 static inline bool PyGreenlet_STARTED(const greenlet::Greenlet* g)
 {
-    return g->stack_state.started();
+    return g->started();
 }
 
 static inline bool PyGreenlet_STARTED(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
@@ -56,7 +56,7 @@ static inline bool PyGreenlet_STARTED(const PyGreenlet* g)
 
 static inline bool PyGreenlet_MAIN(const greenlet::Greenlet* g)
 {
-    return g->stack_state.main();
+    return g->main();
 }
 
 static inline bool PyGreenlet_MAIN(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
@@ -71,7 +71,7 @@ static inline bool PyGreenlet_MAIN(const PyGreenlet* g)
 
 static inline bool PyGreenlet_ACTIVE(const greenlet::Greenlet* g)
 {
-    return g->stack_state.active();
+    return g->active();
 }
 
 static inline bool PyGreenlet_ACTIVE(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
@@ -93,14 +93,14 @@ inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator greenlet::Greenl
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
 
-template <typename T>
-inline Greenlet* greenlet::refs::_OwnedGreenlet<T>::operator->() const G_NOEXCEPT
+template <typename T, greenlet::refs::TypeChecker TC>
+inline greenlet::Greenlet* greenlet::refs::_OwnedGreenlet<T, TC>::operator->() const G_NOEXCEPT
 {
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
 
-template <typename T>
-inline Greenlet* greenlet::refs::_BorrowedGreenlet<T>::operator->() const G_NOEXCEPT
+template <typename T, greenlet::refs::TypeChecker TC>
+inline greenlet::Greenlet* greenlet::refs::_BorrowedGreenlet<T, TC>::operator->() const G_NOEXCEPT
 {
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
@@ -126,7 +126,7 @@ typedef struct _PyMainGreenlet
 // initializers; recent MSVC requires ``/std=c++20`` to use
 // designated initializer, and doesn't permit mixing. And then older
 // MSVC doesn't support any of it.
-static PyTypeObject PyMainGreenlet_Type = {
+PyTypeObject PyMainGreenlet_Type = {
     PyVarObject_HEAD_INIT(NULL, 0)
     "greenlet.main_greenlet", // tp_name
     sizeof(PyMainGreenlet)

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -142,6 +142,7 @@ PyTypeObject PyMainGreenlet_Type = {
   */
 static PyMainGreenlet* green_create_main();
 static PyObject* green_switch(PyGreenlet* self, PyObject* args, PyObject* kwargs);
+static int green_is_gc(BorrowedGreenlet self);
 
 #ifdef __clang__
 #    pragma clang diagnostic pop

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -13,21 +13,24 @@
  *
  * C++ templates and inline functions should go here.
  */
-
+#include "greenlet_compiler_compat.hpp"
+#include "greenlet_cpython_compat.hpp"
+#include "greenlet_exceptions.hpp"
+#include "greenlet_greenlet.hpp"
 
 #define GREENLET_MODULE
 namespace greenlet {
     class ThreadState;
+    class ExceptionState;
 };
 struct _PyMainGreenlet;
 class SwitchingState;
 #define main_greenlet_ptr_t struct _PyMainGreenlet*
 #define switching_state_ptr_t SwitchingState*
+#define exception_state_ptr_t greenlet::ExceptionState
 
 
 #include "greenlet.h"
-#include "greenlet_compiler_compat.hpp"
-#include "greenlet_cpython_compat.hpp"
 
 #include <vector>
 #include <memory>
@@ -111,65 +114,6 @@ namespace greenlet
     };
 
     typedef std::vector<PyGreenlet*, PythonAllocator<PyGreenlet*> > g_deleteme_t;
-
-    class TypeError : public std::runtime_error
-    {
-    public:
-        TypeError(const char* const what) : std::runtime_error(what)
-        {
-            if (!PyErr_Occurred()) {
-                PyErr_SetString(PyExc_TypeError, what);
-            }
-        }
-    };
-
-    class PyErrOccurred : public std::runtime_error
-    {
-    public:
-        PyErrOccurred() : std::runtime_error("")
-        {
-            assert(PyErr_Occurred());
-        }
-
-        PyErrOccurred(PyObject* exc_kind, const char* const msg)
-            : std::runtime_error(msg)
-        {
-            PyErr_SetString(exc_kind, msg);
-        }
-    };
-
-    /**
-     * Calls `Py_FatalError` when constructed, so you can't actually
-     * throw this. It just makes static analysis easier.
-     */
-    class PyFatalError : public std::runtime_error
-    {
-    public:
-        PyFatalError(const char* const msg)
-            : std::runtime_error(msg)
-        {
-            Py_FatalError(msg);
-        }
-    };
-
-    static inline PyObject*
-    Require(PyObject* p)
-    {
-        if (!p) {
-            throw PyErrOccurred();
-        }
-        return p;
-    };
-
-    static inline void
-    Require(const int retval)
-    {
-        if (retval < 0) {
-            throw PyErrOccurred();
-        }
-    };
-
-
 
 };
 

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -34,13 +34,13 @@ namespace greenlet
         // implemented as macros.)
         typedef void (*TypeChecker)(void*);
 
-        static inline void
+        G_FP_TMPL_STATIC inline void
         NoOpChecker(void*)
         {
             return;
         }
 
-        static inline void
+        G_FP_TMPL_STATIC inline void
         GreenletChecker(void *p)
         {
             if (!p) {
@@ -61,7 +61,7 @@ namespace greenlet
             }
         }
 
-        static inline void
+        G_FP_TMPL_STATIC inline void
         MainGreenletExactChecker(void *p)
         {
             if (!p) {
@@ -101,7 +101,7 @@ namespace greenlet
 
         typedef _BorrowedGreenlet<PyGreenlet, GreenletChecker> BorrowedGreenlet;
 
-        static inline void
+        G_FP_TMPL_STATIC inline void
         ContextExactChecker(void *p)
         {
             if (!p) {

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -753,7 +753,7 @@ namespace greenlet {
         return OwnedObject::consuming(PyObject_Call(this->p, args.borrow(), kwargs.borrow()));
     }
 
-    static inline void
+    G_FP_TMPL_STATIC inline void
     ListChecker(void * p)
     {
         if (!p) {

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -674,7 +674,9 @@ namespace greenlet {
     template<typename T, TypeChecker TC>
     inline OwnedObject PyObjectPointer<T, TC>::PyStr() const G_NOEXCEPT
     {
-        assert(this->p);
+        if (!this->p) {
+            return OwnedObject();
+        }
         return OwnedObject::consuming(PyObject_Str(reinterpret_cast<PyObject*>(this->p)));
     }
 
@@ -687,6 +689,9 @@ namespace greenlet {
             // as long as the original object stays around, and we're
             // about to (probably) toss it. Hence the copy to std::string.
             OwnedObject py_str = this->PyStr();
+            if (!py_str) {
+                return "(nil)";
+            }
 #if PY_MAJOR_VERSION >= 3
             return PyUnicode_AsUTF8(py_str.borrow());
 #else

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -841,19 +841,8 @@ namespace greenlet {
         // or allocated, we're responsible for the decref.
         void PyAddObject(const char* name, const long new_bool)
         {
-            // TODO: Debugging cruft that can go away
-            Py_ssize_t cnt;
-            PyObject* raw;
-            {
             OwnedObject p = OwnedObject::consuming(Require(PyBool_FromLong(new_bool)));
-            cnt = p.REFCNT();
-            raw = p.borrow();
             this->PyAddObject(name, p);
-            }
-            // No way that raw is now invalid, even though we decref'd
-            // once,
-            // the module is keeping it alive
-            assert(Py_REFCNT(raw) == cnt);
         }
 
         void PyAddObject(const char* name, const OwnedObject& new_object)

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -413,6 +413,7 @@ namespace greenlet {
         void CLEAR()
         {
             Py_CLEAR(this->p);
+            assert(this->p == nullptr);
         }
     };
 

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -69,9 +69,9 @@ do {                                                    \
     stackref += STACK_MAGIC;                 \
     if (slp_save_state_trampoline((char*)stackref))    \
         return -1;                                     \
-    if (!PyGreenlet_ACTIVE(switching_thread_state))    \
+    if (!switching_thread_state->stack_state.active()) \
         return 1;                                      \
-    stsizediff = switching_thread_state->stack_start - (char*)stackref; \
+    stsizediff = switching_thread_state->stack_state.stack_start() - (char*)stackref; \
 } while (0)
 
 #define SLP_RESTORE_STATE() slp_restore_state_trampoline()

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -35,7 +35,7 @@
 // This is safe beacuse we're protected by the GIL, and if we're
 // running this code, the thread isn't exiting. This also nets us a
 // 10-12% speed improvement.
-class SwitchingState;
+
 namespace greenlet {
     class Greenlet;
 };

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -71,7 +71,7 @@ do {                                                    \
         return -1;                                     \
     if (!switching_thread_state->active()) \
         return 1;                                      \
-    stsizediff = switching_thread_state->stack_state.stack_start() - (char*)stackref; \
+    stsizediff = switching_thread_state->stack_start() - (char*)stackref; \
 } while (0)
 
 #define SLP_RESTORE_STATE() slp_restore_state_trampoline()

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -36,9 +36,6 @@
 // running this code, the thread isn't exiting. This also nets us a
 // 10-12% speed improvement.
 
-namespace greenlet {
-    class Greenlet;
-};
 static greenlet::Greenlet* volatile switching_thread_state = nullptr;
 
 
@@ -72,7 +69,7 @@ do {                                                    \
     stackref += STACK_MAGIC;                 \
     if (slp_save_state_trampoline((char*)stackref))    \
         return -1;                                     \
-    if (!switching_thread_state->stack_state.active()) \
+    if (!switching_thread_state->active()) \
         return 1;                                      \
     stsizediff = switching_thread_state->stack_state.stack_start() - (char*)stackref; \
 } while (0)

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -36,7 +36,10 @@
 // running this code, the thread isn't exiting. This also nets us a
 // 10-12% speed improvement.
 class SwitchingState;
-static PyGreenlet* volatile switching_thread_state = nullptr;
+namespace greenlet {
+    class Greenlet;
+};
+static greenlet::Greenlet* volatile switching_thread_state = nullptr;
 
 
 #ifdef GREENLET_NOINLINE_SUPPORTED

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -119,10 +119,8 @@ private:
     G_NO_COPIES_OF_CLS(ThreadState);
 
 public:
-    static void* operator new(size_t count)
+    static void* operator new(size_t UNUSED(count))
     {
-        UNUSED(count);
-        assert(count == sizeof(ThreadState));
         return ThreadState::allocator.allocate(1);
     }
 

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -238,7 +238,7 @@ private:
                     // exception into it anymore anyway.
                     Py_CLEAR(to_del->main_greenlet_s);
                     if (PyGreenlet_ACTIVE(to_del)) {
-                        assert(to_del->top_frame);
+                        assert(to_del->python_state.has_top_frame());
                         to_del->stack_start = NULL;
                         assert(!PyGreenlet_ACTIVE(to_del));
 
@@ -252,7 +252,7 @@ private:
                         // running and the thread state doesn't have
                         // this frame.)
                         // So here, we *do* clear it.
-                        Py_CLEAR(to_del->top_frame);
+                        to_del->python_state.tp_clear(true);
                     }
                 }
 
@@ -336,7 +336,7 @@ public:
         // on the stack, somewhere uncollectable. Try to detect that.
         if (this->current_greenlet == this->main_greenlet && this->current_greenlet) {
             assert(PyGreenlet_MAIN(this->main_greenlet.borrow()));
-            assert(!this->current_greenlet->top_frame);
+            assert(!this->current_greenlet->python_state.has_top_frame());
             assert(this->main_greenlet->super.main_greenlet_s == this->main_greenlet.borrow());
             // Break a cycle we know about, the self reference
             // the main greenlet keeps.
@@ -410,7 +410,7 @@ public:
         // deleteme list.
         if (this->current_greenlet) {
             OwnedGreenlet& g = this->current_greenlet;
-            assert(!g->top_frame);
+            assert(!g->python_state.has_top_frame());
             Py_CLEAR(g->main_greenlet_s);
             // XXX: This could now put us in an invalid state, with
             // this->current_greenlet not being valid anymore.

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -242,7 +242,7 @@ private:
                     to_del->pimpl->main_greenlet.CLEAR();
 
                     if (PyGreenlet_ACTIVE(to_del)) {
-                        assert(to_del->pimpl->python_state.has_top_frame());
+                        assert(!to_del->pimpl->is_currently_running_in_some_thread());
                         to_del->pimpl->stack_state.set_inactive();
                         assert(!PyGreenlet_ACTIVE(to_del));
 
@@ -340,7 +340,7 @@ public:
         // on the stack, somewhere uncollectable. Try to detect that.
         if (this->current_greenlet == this->main_greenlet && this->current_greenlet) {
             assert(PyGreenlet_MAIN(this->main_greenlet));
-            assert(!this->current_greenlet->python_state.has_top_frame());
+            assert(this->current_greenlet->is_currently_running_in_some_thread());
             assert(this->main_greenlet->main_greenlet == this->main_greenlet.borrow());
             // Break a cycle we know about, the self reference
             // the main greenlet keeps.
@@ -414,7 +414,7 @@ public:
         // deleteme list.
         if (this->current_greenlet) {
             OwnedGreenlet& g = this->current_greenlet;
-            assert(!g->python_state.has_top_frame());
+            assert(!g->is_currently_running_in_some_thread());
             g->main_greenlet.CLEAR();
 
             // XXX: This could now put us in an invalid state, with

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -131,10 +131,9 @@ public:
     }
 
     ThreadState()
+        : main_greenlet(OwnedMainGreenlet::consuming(green_create_main())),
+          current_greenlet(main_greenlet)
     {
-        this->main_greenlet = OwnedMainGreenlet::consuming(green_create_main());
-        this->current_greenlet = main_greenlet;
-
         if(!this->main_greenlet) {
             // We failed to create the main greenlet. That's bad.
             Py_FatalError("Failed to create main greenlet");
@@ -178,11 +177,6 @@ public:
         return this->main_greenlet;
     }
 
-    inline BorrowedGreenlet borrow_current() const
-    {
-        return this->current_greenlet;
-    }
-
     /**
      * In addition to returning a new reference to the currunt
      * greenlet, this perfroms any maintenance needed.
@@ -197,10 +191,14 @@ public:
         return this->current_greenlet;
     };
 
-    // inline bool is_current(const void* obj) const
-    // {
-    //     return this->current_greenlet.borrow() == obj;
-    // }
+    /**
+     * As for get_current();
+     */
+    inline BorrowedGreenlet borrow_current()
+    {
+        this->clear_deleteme_list();
+        return this->current_greenlet;
+    }
 
     template<typename T>
     inline bool is_current(const refs::PyObjectPointer<T>& obj) const
@@ -497,23 +495,6 @@ public:
         return this->state();
     }
 
-    // shadow API to make this easier to use.
-    // inline PyGreenlet* borrow_target()
-    // {
-    //     return this->state().borrow_target();
-    // };
-    inline PyGreenlet* borrow_current()
-    {
-        return this->state().borrow_current().borrow();
-    };
-    // inline PyGreenlet* borrow_origin()
-    // {
-    //     return this->state().borrow_origin().borrow();
-    // };
-    inline PyMainGreenlet* borrow_main_greenlet()
-    {
-        return this->state().borrow_main_greenlet().borrow();
-    };
 
 };
 

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -236,10 +236,11 @@ private:
                 if (murder) {
                     // Force each greenlet to appear dead; we can't raise an
                     // exception into it anymore anyway.
+                    // XXX: If they have saved stack, it leaks!
                     Py_CLEAR(to_del->main_greenlet_s);
                     if (PyGreenlet_ACTIVE(to_del)) {
                         assert(to_del->python_state.has_top_frame());
-                        to_del->stack_start = NULL;
+                        to_del->stack_state.set_inactive();
                         assert(!PyGreenlet_ACTIVE(to_del));
 
                         // We're holding a borrowed reference to the last

--- a/src/greenlet/greenlet_thread_state_dict_cleanup.hpp
+++ b/src/greenlet/greenlet_thread_state_dict_cleanup.hpp
@@ -26,33 +26,41 @@ typedef struct _PyGreenletCleanup {
 } PyGreenletCleanup;
 
 static void
-cleanup_dealloc(PyGreenletCleanup* self)
+cleanup_do_dealloc(PyGreenletCleanup* self)
 {
-    PyObject_GC_UnTrack(self);
     ThreadStateCreator* tmp = self->thread_state_creator;
-    self->thread_state_creator = NULL;
+    self->thread_state_creator = nullptr;
     if (tmp) {
         delete tmp;
     }
+}
 
+static void
+cleanup_dealloc(PyGreenletCleanup* self)
+{
+    PyObject_GC_UnTrack(self);
+    cleanup_do_dealloc(self);
 }
 
 static int
 cleanup_clear(PyGreenletCleanup* self)
 {
-    Py_CLEAR(self->thread_state_creator);
+    // This method is never called by our test cases.
+    cleanup_do_dealloc(self);
     return 0;
 }
 
 static int
 cleanup_traverse(PyGreenletCleanup* self, visitproc visit, void* arg)
 {
-    // TODO: Anything we should traverse? Probably yes.
+    if (self->thread_state_creator) {
+        return self->thread_state_creator->tp_traverse(visit, arg);
+    }
     return 0;
 }
 
 static int
-cleanup_is_gc(PyGreenlet* self)
+cleanup_is_gc(PyGreenlet* UNUSED(self))
 {
     return 1;
 }

--- a/src/greenlet/greenlet_thread_state_dict_cleanup.hpp
+++ b/src/greenlet/greenlet_thread_state_dict_cleanup.hpp
@@ -7,8 +7,6 @@
 #ifdef __clang__
 #    pragma clang diagnostic push
 #    pragma clang diagnostic ignored "-Wmissing-field-initializers"
-#    pragma clang diagnostic ignored "-Wunused-variable"
-#    pragma clang diagnostic ignored "-Wunused-parameter"
 #endif
 
 #ifndef G_THREAD_STATE_DICT_CLEANUP_TYPE

--- a/src/greenlet/tests/_test_extension_cpp.cpp
+++ b/src/greenlet/tests/_test_extension_cpp.cpp
@@ -33,7 +33,10 @@ test_exception_switch_recurse(int depth, int left)
         return NULL;
 
     try {
-        PyGreenlet_Switch(self->parent, NULL, NULL);
+        if (PyGreenlet_Switch(self->parent, NULL, NULL) == NULL) {
+            Py_DECREF(self);
+            return NULL;
+        }
         p_test_exception_throw(depth);
         PyErr_SetString(PyExc_RuntimeError,
                         "throwing C++ exception didn't work");

--- a/src/greenlet/tests/_test_extension_cpp.cpp
+++ b/src/greenlet/tests/_test_extension_cpp.cpp
@@ -62,9 +62,8 @@ test_exception_switch_recurse(int depth, int left)
  * - verifies depth matches (exceptions shouldn't be caught in other greenlets)
  */
 static PyObject*
-test_exception_switch(PyObject* self, PyObject* args)
+test_exception_switch(PyObject* UNUSED(self), PyObject* args)
 {
-    UNUSED(self);
     int depth;
     if (!PyArg_ParseTuple(args, "i", &depth))
         return NULL;

--- a/src/greenlet/tests/_test_extension_cpp.cpp
+++ b/src/greenlet/tests/_test_extension_cpp.cpp
@@ -33,7 +33,7 @@ test_exception_switch_recurse(int depth, int left)
         return NULL;
 
     try {
-        if (PyGreenlet_Switch(self->parent, NULL, NULL) == NULL) {
+        if (PyGreenlet_Switch(PyGreenlet_GET_PARENT(self), NULL, NULL) == NULL) {
             Py_DECREF(self);
             return NULL;
         }

--- a/src/greenlet/tests/test_contextvars.py
+++ b/src/greenlet/tests/test_contextvars.py
@@ -184,7 +184,7 @@ class ContextVarsTests(TestCase):
 
         gr = greenlet(target)
 
-        with self.assertRaisesRegex(AttributeError, "can't delete attr"):
+        with self.assertRaisesRegex(AttributeError, "can't delete context attribute"):
             del gr.gr_context
 
         self.assertIsNone(gr.gr_context)
@@ -274,6 +274,12 @@ class ContextVarsTests(TestCase):
         del holder[:]
         gr = None
         thread = None
+
+    def test_context_assignment_wrong_type(self):
+        g = greenlet()
+        with self.assertRaisesRegex(TypeError,
+                                    "greenlet context must be a contextvars.Context or None"):
+            g.gr_context = self
 
 
 @skipIf(Context is not None, "ContextVar supported")

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -1045,9 +1045,9 @@ class TestRepr(TestCase):
 
         r = repr(t.main_glet)
         # main greenlets, even from dead threads, never really appear dead
-        # TODO: Can we find a better way to differentiate that?
+        # but we can distinguish that the thread is dead
         assert not t.main_glet.dead
-        self.assertEndsWith(r, ' suspended active started main>')
+        self.assertEndsWith(r, ' (thread exited) active started main>')
 
     def test_dead(self):
         g = greenlet(lambda: None)

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -776,7 +776,7 @@ class TestGreenlet(TestCase):
         # Let any other thread run; it will crash the interpreter
         # if not fixed (or silently corrupt memory and we possibly crash
         # later).
-        time.sleep(1)
+        self.wait_for_pending_cleanups()
         self.assertEqual(sys.getrefcount(MyGreenlet), initial_refs)
 
     def test_falling_off_end_switches_to_unstarted_parent_raises_error(self):

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -108,17 +108,18 @@ class TestGreenlet(TestCase):
         lst = []
 
         def f():
-            lst.append(1)
+            lst.append('b')
             greenlet.getcurrent().parent.switch()
 
         def g():
-            lst.append(1)
+            lst.append('a')
             g = greenlet(f)
             g.switch()
-            lst.append(1)
+            lst.append('c')
+
         g = greenlet(g)
         g.switch()
-        self.assertEqual(len(lst), 3)
+        self.assertEqual(lst, ['a', 'b', 'c'])
         self.assertEqual(sys.getrefcount(g), 2)
 
     def test_threads(self):


### PR DESCRIPTION
As per #264. In addition to the primary goal of insulating dependent libraries from changes in greenlet, either internally or to support new Python versions, this refactoring includes some fixes, including:

- Better detection of when a greenlet is from a dead thread, allowing earlier freeing of memory it was holding
- Actually letting main greenlets from dead threads die themselves

While this is a good, stable checkpoint, it has exposed the fact that there is some internal conceptual clearness and perhaps even some efficiency to be gained by furthering the distinction between user-created greenlets and main greenlets. That's a refactoring (in progress) for a followup PR.