### PR TITLE
Drop the separate PyMainGreenlet type

### DIFF
--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -4,7 +4,7 @@
 #include <Python.h>
 #include <memory>
 #include "greenlet_compiler_compat.hpp"
-// #include <iostream>
+
 
 namespace greenlet
 {
@@ -33,13 +33,6 @@ namespace greenlet
 
         T* allocate(size_t number_objects, const void* UNUSED(hint)=0)
         {
-            // using std::cerr;
-            // using std::endl;
-
-            // cerr << "Allocating " << number_objects
-            //      << " at " << UNUSED_hint
-            //      << " from " << typeid(this).name()
-            //      << endl;
             void* p;
             if (number_objects == 1)
                 p = PyObject_Malloc(sizeof(T));
@@ -50,13 +43,6 @@ namespace greenlet
 
         void deallocate(T* t, size_t n)
         {
-            // using std::cerr;
-            // using std::endl;
-            // cerr << "Deallocating " << n
-            //      << " at " << t
-            //      << " of " << typeid(t).name()
-            //      << " from " << typeid(this).name()
-            //      << endl;
             void* p = t;
             if (n == 1) {
                 PyObject_Free(p);

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -12,9 +12,6 @@
 // based on the Python version. Write both versions of the function,
 // one with the WHEN version, one with the WHEN_NOT version.
 // Instantiate the template using the G_IS_PY37 macro.
-// NOTE: The compiler still sees (and type checks) both versions, apparently, even when
-// not instantiated? I didn't think that was how expansion worked, if
-// one template is never needed.
 struct GREENLET_WHEN_PY37
 {
     typedef GREENLET_WHEN_PY37* Yes;

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -579,13 +579,13 @@ namespace greenlet
     private:
         static greenlet::PythonAllocator<MainGreenlet> allocator;
         refs::BorrowedMainGreenlet _self;
-        // TODO: Move the thread state down from the Python type.
-        //ThreadState* _thread_state;
+        ThreadState* _thread_state;
+        G_NO_COPIES_OF_CLS(MainGreenlet);
     public:
         static void* operator new(size_t UNUSED(count));
         static void operator delete(void* ptr);
 
-        MainGreenlet(refs::BorrowedMainGreenlet::PyType*);
+        MainGreenlet(refs::BorrowedMainGreenlet::PyType*, ThreadState*);
         virtual ~MainGreenlet();
 
 
@@ -600,6 +600,7 @@ namespace greenlet
         virtual refs::BorrowedMainGreenlet find_main_greenlet_in_lineage() const;
         virtual bool was_running_in_dead_thread() const G_NOEXCEPT;
         virtual ThreadState* thread_state() const G_NOEXCEPT;
+        void thread_state(ThreadState*) G_NOEXCEPT;
         virtual OwnedObject g_switch();
         virtual BorrowedGreenlet self() const G_NOEXCEPT;
         virtual int tp_traverse(visitproc visit, void* arg);

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -31,67 +31,37 @@ namespace greenlet {
     typedef std::vector<PyGreenlet*, PythonAllocator<PyGreenlet*> > g_deleteme_t;
 
 };
-struct _PyMainGreenlet;
+
 
 #define implementation_ptr_t greenlet::Greenlet*
 
 
 #include "greenlet.h"
 
-
-static inline bool PyGreenlet_STARTED(const greenlet::Greenlet* g)
+G_FP_TMPL_STATIC inline void
+greenlet::refs::MainGreenletExactChecker(void *p)
 {
-    return g->started();
-}
-
-static inline bool PyGreenlet_STARTED(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
-{
-    return PyGreenlet_STARTED(g->pimpl);
-}
-
-static inline bool PyGreenlet_STARTED(const PyGreenlet* g)
-{
-    return PyGreenlet_STARTED(g->pimpl);
-}
-
-static inline bool PyGreenlet_MAIN(const greenlet::Greenlet* g)
-{
-    return g->main();
-}
-
-static inline bool PyGreenlet_MAIN(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
-{
-    return PyGreenlet_MAIN(g->pimpl);
-}
-
-static inline bool PyGreenlet_MAIN(const PyGreenlet* g)
-{
-    return PyGreenlet_MAIN(g->pimpl);
-}
-
-static inline bool PyGreenlet_ACTIVE(const greenlet::Greenlet* g)
-{
-    return g->active();
-}
-
-static inline bool PyGreenlet_ACTIVE(const greenlet::refs::PyObjectPointer<PyGreenlet>& g)
-{
-    return PyGreenlet_ACTIVE(g->pimpl);
-}
-
-static inline bool PyGreenlet_ACTIVE(const PyGreenlet* g)
-{
-    return PyGreenlet_ACTIVE(g->pimpl);
-}
-
-template<>
-inline greenlet::refs::_OwnedGreenlet<PyMainGreenlet>::operator greenlet::Greenlet*() const G_NOEXCEPT
-{
-    if (!this->p) {
-        return nullptr;
+    if (!p) {
+        return;
     }
-    return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
+    // We control the class of the main greenlet exactly.
+    if (Py_TYPE(p) != &PyGreenlet_Type) {
+        throw greenlet::TypeError("Expected a greenlet");
+    }
+
+    // Greenlets from dead threads no longer respond to main() with a
+    // true value; so in that case we need to perform an additional
+    // check.
+    Greenlet* g = ((PyGreenlet*)p)->pimpl;
+    if (g->main()) {
+        return;
+    }
+    if (!dynamic_cast<MainGreenlet*>(g)) {
+        throw greenlet::TypeError("Expected a main greenlet");
+    }
 }
+
+
 
 template <typename T, greenlet::refs::TypeChecker TC>
 inline greenlet::Greenlet* greenlet::refs::_OwnedGreenlet<T, TC>::operator->() const G_NOEXCEPT
@@ -111,36 +81,12 @@ inline greenlet::Greenlet* greenlet::refs::_BorrowedGreenlet<T, TC>::operator->(
 
 extern PyTypeObject PyGreenlet_Type;
 
-// Define a special type for the main greenlets. This way it can have
-// a thread state pointer without having to carry the expense of a
-// NULL field around on every other greenlet.
-// At the Python level, the main greenlet class is
-// *almost* indistinguisable from plain greenlets.
-typedef struct _PyMainGreenlet
-{
-    PyGreenlet super;
-    greenlet::ThreadState* volatile thread_state;
-} PyMainGreenlet;
-
-// GCC and clang support mixing designated and non-designated
-// initializers; recent MSVC requires ``/std=c++20`` to use
-// designated initializer, and doesn't permit mixing. And then older
-// MSVC doesn't support any of it.
-PyTypeObject PyMainGreenlet_Type = {
-    PyVarObject_HEAD_INIT(NULL, 0)
-    "greenlet.main_greenlet", // tp_name
-    sizeof(PyMainGreenlet)
-};
-
-
-
-
 
 
 /**
   * Forward declarations needed in multiple files.
   */
-static PyMainGreenlet* green_create_main();
+static PyGreenlet* green_create_main(greenlet::ThreadState*);
 static PyObject* green_switch(PyGreenlet* self, PyObject* args, PyObject* kwargs);
 static int green_is_gc(BorrowedGreenlet self);
 

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -1106,14 +1106,13 @@ class TestMainGreenlet(TestCase):
         assert 'main' in repr(greenlet.getcurrent())
 
         t = type(greenlet.getcurrent())
-        assert 'main' in repr(t)
+        assert 'main' not in repr(t)
         return t
 
-    def test_main_greenlet_cannot_be_subclassed(self):
+    def test_main_greenlet_type_can_be_subclassed(self):
         main_type = self._check_current_is_main()
-        with self.assertRaises(TypeError):
-            class Subclass(main_type): # pylint:disable=unused-variable
-                pass
+        subclass = type('subclass', (main_type,), {})
+        self.assertIsNotNone(subclass)
 
     def test_main_greenlet_is_greenlet(self):
         self._check_current_is_main()

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -893,6 +893,8 @@ class TestGreenletSetParentErrors(TestCase):
         # cleared, this test is catching whether ``green_setparent``
         # can detect the dead thread.
         #
+        # Further refactoring once again changes this back to a greenlet.error
+        #
         # We need to wait for the cleanup to happen, but we're
         # deliberately leaking a main greenlet here.
         self.wait_for_pending_cleanups(initial_main_greenlets=self.main_greenlets_before_test + 1)
@@ -903,9 +905,10 @@ class TestGreenletSetParentErrors(TestCase):
                     self.parent = another[0] # pylint:disable=attribute-defined-outside-init
                 return greenlet.__getattribute__(self, name)
         g = convoluted(lambda: None)
-        with self.assertRaises(ValueError) as exc:
+        with self.assertRaises(greenlet.error) as exc:
             g.switch()
-        self.assertEqual(str(exc.exception), "parent must not be garbage collected")
+        self.assertEqual(str(exc.exception),
+                         "cannot switch to a different thread (which happens to have exited)")
         del another[:]
 
     def test_unexpected_reparenting_thread_running(self):
@@ -946,10 +949,15 @@ class TestGreenletSetParentErrors(TestCase):
         worker = greenlet(lambda: None)
         self.assertIs(worker.parent, greenlet.getcurrent())
 
-        for g in (worker, greenlet.getcurrent()):
-            with self.assertRaises(AttributeError) as exc:
-                del g.parent
-            self.assertEqual(str(exc.exception), "can't delete attribute")
+        with self.assertRaises(AttributeError) as exc:
+            del worker.parent
+        self.assertEqual(str(exc.exception), "can't delete attribute")
+
+    def test_cannot_delete_parent_of_main(self):
+        with self.assertRaises(AttributeError) as exc:
+            del greenlet.getcurrent().parent
+        self.assertEqual(str(exc.exception), "can't delete attribute")
+
 
     def test_main_greenlet_parent_is_none(self):
         # assuming we're in a main greenlet here.
@@ -979,17 +987,18 @@ class TestGreenletSetParentErrors(TestCase):
         # Let it finish
         g.switch()
 
-    def _check_trivial_cycle(self, glet):
+
+    def test_trivial_cycle(self):
+        glet = greenlet(lambda: None)
         with self.assertRaises(ValueError) as exc:
             glet.parent = glet
         self.assertEqual(str(exc.exception), "cyclic parent chain")
 
-    def test_trivial_cycle(self):
-        glet = greenlet(lambda: None)
-        self._check_trivial_cycle(glet)
-
     def test_trivial_cycle_main(self):
-        self._check_trivial_cycle(greenlet.getcurrent())
+        # This used to produce a ValueError, but we catch it earlier than that now.
+        with self.assertRaises(AttributeError) as exc:
+            greenlet.getcurrent().parent = greenlet.getcurrent()
+        self.assertEqual(str(exc.exception), "cannot set the parent of a main greenlet")
 
     def test_deeper_cycle(self):
         g1 = greenlet(lambda: None)


### PR DESCRIPTION
Which was (necessarily) exposed to Python, in favor of keeping that entirely internal.