### PR TITLE
Extend the unhandled C++ exception tests to Windows

### DIFF
--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -1154,11 +1154,18 @@ UserGreenlet::inner_bootstrap(OwnedGreenlet& origin_greenlet, OwnedObject& run) 
             result = run.PyCall(args.args(), args.kwargs());
         }
         catch(...) {
-            // Unhandled exception! Try to recover.
-            // If we don't catch this here, most platforms will just
-            // abort() the process. But 64-bit Windows, because of the
-            // way SEH works, can actually corrupt memory.
-            PyErr_SetString(PyExc_RuntimeError, "Unexpected C++ exception caught.");
+            // Unhandled exception! If we don't catch this here, most
+            // platforms will just abort() the process. But on 64-bit
+            // Windows with older versions of the C runtime, this can
+            // actually corrupt memory and just return. We see this
+            // when compiling with the Windows 7.0 SDK targeting
+            // Windows Server 2008, but not when using the Appveyor
+            // Visual Studio 2019 image. So this currently only
+            // affects Python 2.7 on Windows 64. That is, the tests
+            // pass and the runtime aborts. But if we catch it and try
+            // to continue with a Python error, then all Windows 64
+            // bit platforms corrupt memory. So all we can do is abort.
+            abort();
         }
     }
     args.CLEAR();

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -1150,7 +1150,16 @@ UserGreenlet::inner_bootstrap(OwnedGreenlet& origin_greenlet, OwnedObject& run) 
     else {
         /* call g.run(*args, **kwargs) */
         // This could result in further switches
-        result = run.PyCall(args.args(), args.kwargs());
+        try {
+            result = run.PyCall(args.args(), args.kwargs());
+        }
+        catch(...) {
+            // Unhandled exception! Try to recover.
+            // If we don't catch this here, most platforms will just
+            // abort() the process. But 64-bit Windows, because of the
+            // way SEH works, can actually corrupt memory.
+            PyErr_SetString(PyExc_RuntimeError, "Unexpected C++ exception caught.");
+        }
     }
     args.CLEAR();
     run.CLEAR();

--- a/src/greenlet/tests/test_cpp.py
+++ b/src/greenlet/tests/test_cpp.py
@@ -1,7 +1,9 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-
+import unittest
+import os
+import signal
 
 import greenlet
 from . import _test_extension_cpp
@@ -16,3 +18,45 @@ class CPPTests(TestCase):
             greenlets.append(g)
         for i, g in enumerate(greenlets):
             self.assertEqual(g.switch(), i)
+
+    @unittest.skipUnless(hasattr(os, 'fork'),
+        "test should abort when run -> need to run it in separate process")
+    def test_exception_switch_and_throw(self):
+        # procrun runs f in separate process
+        def procrun(f): # -> (ret, sig, coredumped)
+            pid = os.fork()
+
+            # child
+            if pid == 0:
+                f()
+                os.exit(0)
+
+            # parent
+            _, st = os.waitpid(pid, 0)
+            ret = st >> 8
+            sig = st & 0x7f
+            coredumped = ((st & 0x80) != 0)
+            return (ret, sig, coredumped)
+
+
+        # verify that plain unhandled throw aborts
+        # (unhandled throw -> std::terminate -> abort)
+        ret, sig, _ = procrun(_test_extension_cpp.test_exception_throw)
+        if not (ret == 0 and sig == signal.SIGABRT):
+            self.fail("unhandled throw -> ret=%d sig=%d  ; expected 0/SIGABRT" % (ret, sig))
+
+
+        # verify that unhandled throw called in greenlet aborts too
+        # (does not segfaults nor is handled by try/catch on preceeding greenlet C stack)
+        def _():
+            def _():
+                _test_extension_cpp.test_exception_switch_and_do_in_g2(
+                    _test_extension_cpp.test_exception_throw
+                )
+            g1 = greenlet.greenlet(_)
+            g1.switch()
+
+        ret, sig, core = procrun(_)
+        if not (ret == 0 and sig == signal.SIGABRT):
+            self.fail("failed with ret=%d sig=%d%s" %
+                      (ret, sig, " (core dumped)" if core else ""))

--- a/src/greenlet/tests/test_cpp.py
+++ b/src/greenlet/tests/test_cpp.py
@@ -28,20 +28,38 @@ class CPPTests(TestCase):
         for i, g in enumerate(greenlets):
             self.assertEqual(g.switch(), i)
 
-    def test_unhandled_exception_aborts(self):
-        # verify that plain unhandled throw aborts
-
+    def _do_test_unhandled_exception(self, target):
         # TODO: On some versions of Python with some settings, this
         # spews a lot of garbage to stderr. It would be nice to capture and ignore that.
-        p = Process(target=_test_extension_cpp.test_exception_throw)
+        import sys
+        WIN = sys.platform.startswith("win")
+
+        p = Process(target=target)
         p.start()
         p.join(10)
-        self.assertEqual(p.exitcode, - signal.SIGABRT)
+        # The child should be aborted in an unusual way. On POSIX
+        # platforms, this is done with abort() and signal.SIGABRT,
+        # which is reflected in a negative return value; however, on
+        # Windows, even though we observe the child print "Fatal
+        # Python error: Aborted" and in older versions of the C
+        # runtime "This application has requested the Runtime to
+        # terminate it in an unusual way," it always has an exit code
+        # of 3. This is interesting because 3 is the error code for
+        # ERROR_PATH_NOT_FOUND; BUT: the C runtime abort() function
+        # also uses this code.
+        #
+        # See
+        # https://devblogs.microsoft.com/oldnewthing/20110519-00/?p=10623
+        # and
+        # https://docs.microsoft.com/en-us/previous-versions/k089yyh0(v=vs.140)?redirectedfrom=MSDN
+        expected_exit = -signal.SIGABRT if not WIN else 3
+        self.assertEqual(p.exitcode, expected_exit)
+
+    def test_unhandled_exception_aborts(self):
+        # verify that plain unhandled throw aborts
+        self._do_test_unhandled_exception(_test_extension_cpp.test_exception_throw)
+
 
     def test_unhandled_exception_in_greenlet_aborts(self):
         # verify that unhandled throw called in greenlet aborts too
-        # TODO: See test_unhandled_exception_aborts
-        p = Process(target=run_unhandled_exception_in_greenlet_aborts)
-        p.start()
-        p.join(10)
-        self.assertEqual(p.exitcode, - signal.SIGABRT)
+        self._do_test_unhandled_exception(run_unhandled_exception_in_greenlet_aborts)

--- a/src/greenlet/tests/test_cpp.py
+++ b/src/greenlet/tests/test_cpp.py
@@ -1,13 +1,22 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import unittest
-import os
 import signal
+from multiprocessing import Process
 
 import greenlet
 from . import _test_extension_cpp
 from . import TestCase
+
+def run_unhandled_exception_in_greenlet_aborts():
+    # This is used in multiprocessing.Process and must be picklable
+    # so it needs to be global.
+    def _():
+        _test_extension_cpp.test_exception_switch_and_do_in_g2(
+            _test_extension_cpp.test_exception_throw
+        )
+    g1 = greenlet.greenlet(_)
+    g1.switch()
 
 class CPPTests(TestCase):
     def test_exception_switch(self):
@@ -19,44 +28,20 @@ class CPPTests(TestCase):
         for i, g in enumerate(greenlets):
             self.assertEqual(g.switch(), i)
 
-    @unittest.skipUnless(hasattr(os, 'fork'),
-        "test should abort when run -> need to run it in separate process")
-    def test_exception_switch_and_throw(self):
-        # procrun runs f in separate process
-        def procrun(f): # -> (ret, sig, coredumped)
-            pid = os.fork()
-
-            # child
-            if pid == 0:
-                f()
-                os.exit(0)
-
-            # parent
-            _, st = os.waitpid(pid, 0)
-            ret = st >> 8
-            sig = st & 0x7f
-            coredumped = ((st & 0x80) != 0)
-            return (ret, sig, coredumped)
-
-
+    def test_unhandled_exception_aborts(self):
         # verify that plain unhandled throw aborts
-        # (unhandled throw -> std::terminate -> abort)
-        ret, sig, _ = procrun(_test_extension_cpp.test_exception_throw)
-        if not (ret == 0 and sig == signal.SIGABRT):
-            self.fail("unhandled throw -> ret=%d sig=%d  ; expected 0/SIGABRT" % (ret, sig))
 
+        # TODO: On some versions of Python with some settings, this
+        # spews a lot of garbage to stderr. It would be nice to capture and ignore that.
+        p = Process(target=_test_extension_cpp.test_exception_throw)
+        p.start()
+        p.join(10)
+        self.assertEqual(p.exitcode, - signal.SIGABRT)
 
+    def test_unhandled_exception_in_greenlet_aborts(self):
         # verify that unhandled throw called in greenlet aborts too
-        # (does not segfaults nor is handled by try/catch on preceeding greenlet C stack)
-        def _():
-            def _():
-                _test_extension_cpp.test_exception_switch_and_do_in_g2(
-                    _test_extension_cpp.test_exception_throw
-                )
-            g1 = greenlet.greenlet(_)
-            g1.switch()
-
-        ret, sig, core = procrun(_)
-        if not (ret == 0 and sig == signal.SIGABRT):
-            self.fail("failed with ret=%d sig=%d%s" %
-                      (ret, sig, " (core dumped)" if core else ""))
+        # TODO: See test_unhandled_exception_aborts
+        p = Process(target=run_unhandled_exception_in_greenlet_aborts)
+        p.start()
+        p.join(10)
+        self.assertEqual(p.exitcode, - signal.SIGABRT)


### PR DESCRIPTION
Fixes #285 

There is currently a failure on 64-bit windows:
```
 test_unhandled_exception_in_greenlet_aborts (greenlet.tests.test_cpp.CPPTests)
C++ exception unexpectedly caught in g1
Windows exception: access violation

Current thread 0x00000a64 (most recent call first):
Failure in test test_unhandled_exception_in_greenlet_aborts (greenlet.tests.test_cpp.CPPTests)
Traceback (most recent call last):
  File "C:\Python27-x64\lib\unittest\case.py", line 329, in run
    testMethod()
  File "c:\projects\greenlet\src\greenlet\tests\leakcheck.py", line 316, in wrapper
    return _RefCountChecker(self, method)(args, kwargs)
  File "c:\projects\greenlet\src\greenlet\tests\leakcheck.py", line 294, in __call__
    self._run_test(args, kwargs)
  File "c:\projects\greenlet\src\greenlet\tests\leakcheck.py", line 212, in _run_test
    self.function(self.testcase, *args, **kwargs)
  File "c:\projects\greenlet\src\greenlet\tests\test_cpp.py", line 65, in test_unhandled_exception_in_greenlet_aborts
    self._do_test_unhandled_exception(run_unhandled_exception_in_greenlet_aborts)
  File "c:\projects\greenlet\src\greenlet\tests\test_cpp.py", line 56, in _do_test_unhandled_exception
    self.assertEqual(p.exitcode, expected_exit)
  File "C:\Python27-x64\lib\unittest\case.py", line 513, in assertEqual
    assertion_func(first, second, msg=msg)
  File "C:\Python27-x64\lib\unittest\case.py", line 506, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: -1073741819 != 3
```

