### PR TITLE
Fix compilation error for RISC-V

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,8 @@ if ((sys.platform == "openbsd4" and os.uname()[-1] == "i386")
     or ("-with-redhat-3." in platform.platform() and platform.machine() == 'i686')
     or (sys.platform == "sunos5" and os.uname()[-1] == "sun4v")
     or ("SunOS" in platform.platform() and platform.machine() == "sun4v")
-    or (is_linux and platform.machine() == "ppc")):
+    or (is_linux and platform.machine() == "ppc")
+    or (is_linux and platform.machine() == "riscv64")):
     global_compile_args.append("-Os")
 
 


### PR DESCRIPTION
When compiling for RISC-V the command 
riscv64-linux-gnu-gcc -pthread -fno-strict-aliasing -Wdate-time -D_FORTIFY_SOURCE=2 -g -ffile-prefix-map=/build/python2.7-7GU7VT/python2.7-2.7.18=. -fstack-protector-strong -Wformat -Werror=format-security -fPIC -I/usr/include/python2.7 -c src/greenlet/greenlet.cpp -o build/temp.linux-riscv64-2.7/src/greenlet/greenlet.o
fails with:
src/greenlet/platform/switch_riscv_unix.h:30:1: error: s0 cannot be used in ‘asm’ here

Adding the -Os fixes the problem.