### PR TITLE
Clarify that const is being cast away

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__/
 /.ropeproject/
 /MANIFEST
 benchmarks/*.json
+.vscode

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -339,7 +339,7 @@ namespace greenlet {
             Py_XINCREF(other.p);
             const T* tmp = this->p;
             this->p = other.p;
-            Py_XDECREF(tmp);
+            Py_XDECREF(const_cast<T*>(tmp));
             return *this;
         }
 
@@ -851,7 +851,7 @@ namespace greenlet {
 
         void PyAddObject(const char* name, const PyObject* new_object)
         {
-            Py_INCREF(new_object);
+            Py_INCREF(const_cast<PyObject*>(new_object));
             try {
                 Require(PyModule_AddObject(this->p, name, const_cast<PyObject*>(new_object)));
             }


### PR DESCRIPTION
~Closes #301~

I should preface this with a disclaimer that my c++ is very rusty and this is the first time I have looked at this code base.  I expect this is not the correct fix, but it compiles!  I get one failure locally (see below).

https://github.com/python/cpython/pull/91959 switch to using "new-style" c++ casts which are (apparently) stricter about casts.  

One set of changes is to explicitly strip const when passing into the C API (to increase / decrease reference counts).  I think this used to work because const-ness was being ignored before.  Although this was fixed upstream to work, I think it is better to still have the explicit casting.

~The other set of changes is to borrow the PyObject pointer from the greenlet wrapper classes.  I think this used to work because the pointer was the first element in the wrapped objected so it is safe to directly cast it, however the new-style casting balks.~ (dropped this commit)