### PR TITLE
Fixed missing PY_SSIZE_T_CLEAN define before python.h import

### DIFF
--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -11,6 +11,7 @@
 #include <exception>
 
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "structmember.h" // PyMemberDef
 

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -5,6 +5,7 @@
 #ifndef Py_GREENLETOBJECT_H
 #define Py_GREENLETOBJECT_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #ifdef __cplusplus

--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_ALLOCATOR_HPP
 #define GREENLET_ALLOCATOR_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <memory>
 #include "greenlet_compiler_compat.hpp"

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -6,6 +6,7 @@
  * Helpers for compatibility with multiple versions of CPython.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 // These enable writing template functions or classes specialized

--- a/src/greenlet/greenlet_exceptions.hpp
+++ b/src/greenlet/greenlet_exceptions.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_EXCEPTIONS_HPP
 #define GREENLET_EXCEPTIONS_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdexcept>
 

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -4,6 +4,7 @@
  * Declarations of the core data structures.
 */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 //#include "greenlet_internal.hpp"
 #include "greenlet_compiler_compat.hpp"

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_REFS_HPP
 #define GREENLET_REFS_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 //#include "greenlet_internal.hpp"
 #include "greenlet_compiler_compat.hpp"


### PR DESCRIPTION
This fixes the following error, when running on Python3.10:

    SystemError: PY_SSIZE_T_CLEAN macro must be defined for '#' formats

According to https://docs.python.org/3/c-api/intro.html#include-files

> All function, type and macro definitions needed to use the Python/C API are included in your code by the following line:
>
>```
>#define PY_SSIZE_T_CLEAN
>#include <Python.h>
>```