### PR TITLE
Internally define PY_SSIZE_T_CLEAN

### DIFF
--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -11,6 +11,7 @@
 #include <exception>
 
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include "structmember.h" // PyMemberDef
 

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -5,6 +5,7 @@
 #ifndef Py_GREENLETOBJECT_H
 #define Py_GREENLETOBJECT_H
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 
 #ifdef __cplusplus

--- a/src/greenlet/greenlet.h
+++ b/src/greenlet/greenlet.h
@@ -5,7 +5,7 @@
 #ifndef Py_GREENLETOBJECT_H
 #define Py_GREENLETOBJECT_H
 
-#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
 
 #ifdef __cplusplus

--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_ALLOCATOR_HPP
 #define GREENLET_ALLOCATOR_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <memory>
 #include "greenlet_compiler_compat.hpp"

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -6,6 +6,7 @@
  * Helpers for compatibility with multiple versions of CPython.
  */
 
+#define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
 // These enable writing template functions or classes specialized

--- a/src/greenlet/greenlet_exceptions.hpp
+++ b/src/greenlet/greenlet_exceptions.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_EXCEPTIONS_HPP
 #define GREENLET_EXCEPTIONS_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 #include <stdexcept>
 

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -6,7 +6,7 @@
 
 #define PY_SSIZE_T_CLEAN
 #include <Python.h>
-//#include "greenlet_internal.hpp"
+
 #include "greenlet_compiler_compat.hpp"
 #include "greenlet_refs.hpp"
 #include "greenlet_cpython_compat.hpp"

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -4,6 +4,7 @@
  * Declarations of the core data structures.
 */
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 //#include "greenlet_internal.hpp"
 #include "greenlet_compiler_compat.hpp"

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -13,6 +13,7 @@
  *
  * C++ templates and inline functions should go here.
  */
+#define PY_SSIZE_T_CLEAN
 #include "greenlet_compiler_compat.hpp"
 #include "greenlet_cpython_compat.hpp"
 #include "greenlet_exceptions.hpp"

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -1,6 +1,7 @@
 #ifndef GREENLET_REFS_HPP
 #define GREENLET_REFS_HPP
 
+#define PY_SSIZE_T_CLEAN
 #include <Python.h>
 //#include "greenlet_internal.hpp"
 #include "greenlet_compiler_compat.hpp"

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -15,7 +15,7 @@ typedef struct _greenlet PyGreenlet;
 extern PyTypeObject PyGreenlet_Type;
 
 
-#ifndef NDEBUG
+#ifdef  GREENLET_USE_STDIO
 #include <iostream>
 using std::cerr;
 using std::endl;
@@ -244,7 +244,7 @@ namespace greenlet {
         }
     };
 
-#ifndef NDEBUG
+#ifdef GREENLET_USE_STDIO
         template<typename T, TypeChecker TC>
         std::ostream& operator<<(std::ostream& os, const PyObjectPointer<T, TC>& s)
         {


### PR DESCRIPTION
But not in greenlet.h; I don't feel right defining something that can change the way CPython works for clients of our API. They need to opt-in to that.