### PR TITLE
Python 3.11: Fix a memory leak switching to greenlets.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 2.0.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Python 3.11: Fix a memory leak. See `issue 328
+  <https://github.com/python-greenlet/greenlet/issues/328>`_ and
+  `gevent issue 1924 <https://github.com/gevent/gevent/issues/1924>`_.
 
 
 2.0.0.post0 (2022-11-03)
@@ -154,12 +156,17 @@ Changes
 
 - Add musllinux (Alpine) binary wheels.
 
+.. important:: This preliminary support for Python 3.11 leaks memory.
+               Please upgrade to greenlet 2 if you're using Python 3.11.
 
 1.1.3 (2022-08-25)
 ==================
 
 - Add support for Python 3.11. Please note that Windows binary wheels
   are not available at this time.
+
+.. important:: This preliminary support for Python 3.11 leaks memory.
+               Please upgrade to greenlet 2 if you're using Python 3.11.
 
 1.1.2 (2021-09-29)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -226,7 +226,8 @@ setup(
         ],
         'test': [
             'objgraph',
-             'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"',
+            'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"',
+            'psutil',
         ],
     },
     python_requires=">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*",

--- a/src/greenlet/tests/__init__.py
+++ b/src/greenlet/tests/__init__.py
@@ -45,6 +45,7 @@ class TestCaseMetaClass(type):
                 classDict[key] = value
         return type.__new__(cls, classname, bases, classDict)
 
+
 class TestCase(TestCaseMetaClass(
         "NewBase",
         (unittest.TestCase,),

--- a/src/greenlet/tests/test_cpp.py
+++ b/src/greenlet/tests/test_cpp.py
@@ -11,6 +11,8 @@ from . import TestCase
 def run_unhandled_exception_in_greenlet_aborts():
     # This is used in multiprocessing.Process and must be picklable
     # so it needs to be global.
+
+
     def _():
         _test_extension_cpp.test_exception_switch_and_do_in_g2(
             _test_extension_cpp.test_exception_throw
@@ -63,3 +65,7 @@ class CPPTests(TestCase):
     def test_unhandled_exception_in_greenlet_aborts(self):
         # verify that unhandled throw called in greenlet aborts too
         self._do_test_unhandled_exception(run_unhandled_exception_in_greenlet_aborts)
+
+
+if __name__ == '__main__':
+    __import__('unittest').main()


### PR DESCRIPTION
This leak was present in the original implementation of Python 3.11 support (#306)

Fixes #328 and fixes https://github.com/gevent/gevent/issues/1924 ; I have run gevent's test suite locally on 3.11 with this fix without seeing any regressions. See the gevent issue, and the comments in the code, for a deeper explanation.