### PR TITLE
greenlet_allocator.hpp: add missing 'rebind' type

### DIFF
--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -52,6 +52,9 @@ namespace greenlet
                 PyMem_Free(p);
         }
 
+        template <class U> struct rebind {
+            typedef PythonAllocator<U> other;
+        };
     };
 }
 


### PR DESCRIPTION
`gcc-13` added an assert to standard headers to make sure custom allocators have intended implementation of `rebind` type instead of unintentionally inherited `rebind`. gcc change:

    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=64c986b49558a7

Without the fix build fails on this week's `gcc-13` as:

    In file included from src/greenlet/greenlet_greenlet.hpp:13,
                     from src/greenlet/greenlet_internal.hpp:20,
                     from src/greenlet/greenlet.cpp:19:
    src/greenlet/greenlet_allocator.hpp:56:21:
      error: ‘secure_allocator_t’ does not name a type
       56 |             typedef secure_allocator_t<U> other;
          |                     ^~~~~~~~~~~~~~~~~~