### PR TITLE
greenlet: Drop using 'register' storage class keyword

### DIFF
--- a/src/greenlet/platform/switch_riscv_unix.h
+++ b/src/greenlet/platform/switch_riscv_unix.h
@@ -11,8 +11,8 @@
 static int
 slp_switch(void)
 {
-  register int ret;
-  register long *stackref, stsizediff;
+  int ret;
+  long *stackref, stsizediff;
   __asm__ volatile ("" : : : REGS_TO_SAVE);
   __asm__ volatile ("mv %0, sp" : "=r" (stackref) : );
   {


### PR DESCRIPTION
This has been dropped in c++17 and newer

Signed-off-by: Khem Raj <raj.khem@gmail.com>