### PR TITLE
Stop using 'const PyObject*', per @vstinner

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,8 @@ jobs:
       run: |
         python -m pip install -U pip setuptools wheel
         python -m pip install -U twine
-    - name: Install greenlet
+    - name: Install greenlet (non-Mac)
+      if: ${{ ! startsWith(runner.os, 'Mac') }}
       run: |
         python setup.py bdist_wheel
         python -m pip install -U -e ".[test,docs]"
@@ -53,6 +54,18 @@ jobs:
         # process-wide effects), we test with Ofast here, because we
         # expect that some people will compile it themselves with that setting.
         CPPFLAGS: "-Ofast -UNDEBUG"
+    - name: Install greenlet (Mac)
+      if: startsWith(runner.os, 'Mac')
+      run: |
+        python setup.py bdist_wheel
+        python -m pip install -U -e ".[test,docs]"
+      env:
+        # Unlike the above, we are actually distributing these
+        # wheels, so they need to be built for production use.
+        CPPFLAGS: "-O3"
+        # Build for both architectures
+        ARCHFLAGS: "-arch x86_64 -arch arm64"
+
     - name: Check greenlet build
       run: |
         ls -l dist

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,9 @@
 - Fix calling ``greenlet.settrace()`` with the same tracer object that
   was currently active. See `issue 332
   <https://github.com/python-greenlet/greenlet/issues/332>`_.
-- Various compilation and standards conformance fixes. See #335, #336, #300.
+- Various compilation and standards conformance fixes. See #335, #336,
+  #300, #302.
+
 
 
 2.0.1 (2022-11-07)

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -225,7 +225,7 @@ namespace greenlet {
         inline OwnedObject PyRequireAttr(const ImmortalObject& name) const;
         inline OwnedObject PyCall(const BorrowedObject& arg) const;
         inline OwnedObject PyCall(PyGreenlet* arg) const ;
-        inline OwnedObject PyCall(const PyObject* arg) const ;
+        inline OwnedObject PyCall(PyObject* arg) const ;
         // PyObject_Call(this, args, kwargs);
         inline OwnedObject PyCall(const BorrowedObject args,
                                   const BorrowedObject kwargs) const;
@@ -714,11 +714,11 @@ namespace greenlet {
     template<typename T, TypeChecker TC>
     inline OwnedObject PyObjectPointer<T, TC>::PyCall(PyGreenlet* arg) const
     {
-        return this->PyCall(reinterpret_cast<const PyObject*>(arg));
+        return this->PyCall(reinterpret_cast<PyObject*>(arg));
     }
 
     template<typename T, TypeChecker TC>
-    inline OwnedObject PyObjectPointer<T, TC>::PyCall(const PyObject* arg) const
+    inline OwnedObject PyObjectPointer<T, TC>::PyCall(PyObject* arg) const
     {
         assert(this->p);
         return OwnedObject::consuming(PyObject_CallFunctionObjArgs(this->p, arg, NULL));
@@ -845,16 +845,16 @@ namespace greenlet {
             this->PyAddObject(name, new_object.borrow());
         }
 
-        void PyAddObject(const char* name, const PyTypeObject& type)
+        void PyAddObject(const char* name, PyTypeObject& type)
         {
-            this->PyAddObject(name, reinterpret_cast<const PyObject*>(&type));
+            this->PyAddObject(name, reinterpret_cast<PyObject*>(&type));
         }
 
-        void PyAddObject(const char* name, const PyObject* new_object)
+        void PyAddObject(const char* name, PyObject* new_object)
         {
             Py_INCREF(new_object);
             try {
-                Require(PyModule_AddObject(this->p, name, const_cast<PyObject*>(new_object)));
+                Require(PyModule_AddObject(this->p, name, new_object));
             }
             catch (const PyErrOccurred&) {
                 Py_DECREF(p);

--- a/src/greenlet/platform/switch_aarch64_gcc.h
+++ b/src/greenlet/platform/switch_aarch64_gcc.h
@@ -26,7 +26,7 @@ slp_switch(void)
 {
 	int err;
 	void *fp;
-        register long *stackref, stsizediff;
+        long *stackref, stsizediff;
         __asm__ volatile ("" : : : REGS_TO_SAVE);
 	__asm__ volatile ("str x29, %0" : "=m"(fp) : : );
         __asm__ ("mov %0, sp" : "=r" (stackref));
@@ -59,6 +59,15 @@ slp_switch(void)
 		   stack space), and the simplest is to call a function
 		   that returns an unknown value (which happens to be zero),
 		   so the saved/restored value is unused.  */
+                /* XXX: This line produces warnings:
+
+                   value size does not match register size specified by the
+                   constraint and modifier
+
+                   The suggested fix is to change %0 to %w0.
+
+                   TODO: Validate and change that.
+                 */
            __asm__ volatile ("mov %0, #0" : "=r" (err));
         }
         __asm__ volatile ("ldr x29, %0" : : "m" (fp) :);


### PR DESCRIPTION
See also https://github.com/python/cpython/issues/91768

Fixes #302

Also stops building the mac wheels we ship with Ofast and debugging assertions. That's not meant for production use.