### PR TITLE
PythonAllocator: define missing 'rebind' type

### DIFF
--- a/src/greenlet/greenlet_allocator.hpp
+++ b/src/greenlet/greenlet_allocator.hpp
@@ -32,6 +32,11 @@ namespace greenlet
 
         PythonAllocator() : std::allocator<T>() {}
 
+        template <class U> struct rebind
+        {
+            typedef PythonAllocator<U> other;
+        };
+
         T* allocate(size_t number_objects, const void* UNUSED(hint)=0)
         {
             void* p;


### PR DESCRIPTION
`gcc-13` added an assert to standard headers to make sure custom allocators have intended implementation of rebind type instead of inherited rebind. gcc change:
    https://gcc.gnu.org/git/?p=gcc.git;a=commitdiff;h=64c986b49558a7

Without the fix build fails on this week's `gcc-13` as:

| In file included from ../recipe-sysroot/usr/include/c++/13.0.1/ext/alloc_traits.h:34,
|                  from ../recipe-sysroot/usr/include/c++/13.0.1/bits/basic_string.h:39,
|                  from ../recipe-sysroot/usr/include/c++/13.0.1/string:54,
|                  from src/greenlet/greenlet.cpp:10:
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/alloc_traits.h: In instantiation of 'struct std::__allocator_traits_base::__rebind<greenlet::PythonAllocator<_greenlet*>, _greenlet*, void>':
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/alloc_traits.h:94:11:   required by substitution of 'template<class _Alloc, class _Up> using std::__alloc_rebind = typename std::__allocator_traits_base::__rebind<_Alloc, _Up>::type [with _Alloc = greenlet::PythonAllocator<_greenlet*>; _Up = _greenlet*]'
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/alloc_traits.h:228:8:   required by substitution of 'template<class _Alloc> template<class _Tp> using std::allocator_traits< <template-parameter-1-1> >::rebind_alloc = std::__alloc_rebind<_Alloc, _Tp> [with _Tp = _greenlet*; _Alloc = greenlet::PythonAllocator<_greenlet*>]'
| ../recipe-sysroot/usr/include/c++/13.0.1/ext/alloc_traits.h:126:65:   required from 'struct __gnu_cxx::__alloc_traits<greenlet::PythonAllocator<_greenlet*>, _greenlet*>::rebind<_greenlet*>'
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/stl_vector.h:88:21:   required from 'struct std::_Vector_base<_greenlet*, greenlet::PythonAllocator<_greenlet*> >'
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/stl_vector.h:423:11:   required from 'class std::vector<_greenlet*, greenlet::PythonAllocator<_greenlet*> >'
| src/greenlet/greenlet_thread_state.hpp:115:16:   required from here
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/alloc_traits.h:70:31: error: static assertion failed: allocator_traits<A>::rebind_alloc<A::value_type> must be A
|    70 |                         _Tp>::value,
|       |                               ^~~~~
| ../recipe-sysroot/usr/include/c++/13.0.1/bits/alloc_traits.h:70:31: note: 'std::integral_constant<bool, false>::value' evaluates to false

The change adds trivial `rebind` definition with expected return type and satisfies conversion requirements.

Signed-off-by: Khem Raj <raj.khem@gmail.com>