### PR TITLE
cleanup: Drop using 'register' storage class keyword everywhere

### DIFF
--- a/src/greenlet/platform/switch_alpha_unix.h
+++ b/src/greenlet/platform/switch_alpha_unix.h
@@ -9,8 +9,8 @@
 static int
 slp_switch(void)
 {
-  register int ret;
-  register long *stackref, stsizediff;
+  int ret;
+  long *stackref, stsizediff;
   __asm__ volatile ("" : : : REGS_TO_SAVE);
   __asm__ volatile ("mov $30, %0" : "=r" (stackref) : );
   {

--- a/src/greenlet/platform/switch_arm32_gcc.h
+++ b/src/greenlet/platform/switch_arm32_gcc.h
@@ -56,7 +56,7 @@ __attribute__((optimize("no-omit-frame-pointer")))
 slp_switch(void)
 {
         void *fp;
-        register int *stackref, stsizediff;
+        int *stackref, stsizediff;
         int result;
         __asm__ volatile ("" : : : REGS_TO_SAVE);
         __asm__ volatile ("mov r0," REG_FP "\n\tstr r0,%0" : "=m" (fp) : : "r0");

--- a/src/greenlet/platform/switch_arm32_ios.h
+++ b/src/greenlet/platform/switch_arm32_ios.h
@@ -38,7 +38,7 @@ __attribute__((optimize("no-omit-frame-pointer")))
 slp_switch(void)
 {
         void *fp;
-        register int *stackref, stsizediff, result;
+        int *stackref, stsizediff, result;
         __asm__ volatile ("" : : : REGS_TO_SAVE);
         __asm__ volatile ("str " REG_FP ",%0" : "=m" (fp));
         __asm__ ("mov %0," REG_SP : "=r" (stackref));

--- a/src/greenlet/platform/switch_csky_gcc.h
+++ b/src/greenlet/platform/switch_csky_gcc.h
@@ -23,7 +23,7 @@ __attribute__((optimize("no-omit-frame-pointer")))
 #endif
 slp_switch(void)
 {
-        register int *stackref, stsizediff;
+        int *stackref, stsizediff;
         int result;
 
         __asm__ volatile ("" : : : REGS_TO_SAVE);

--- a/src/greenlet/platform/switch_mips_unix.h
+++ b/src/greenlet/platform/switch_mips_unix.h
@@ -19,8 +19,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
 #ifdef __mips64
     uint64_t gpsave;
 #endif

--- a/src/greenlet/platform/switch_ppc64_aix.h
+++ b/src/greenlet/platform/switch_ppc64_aix.h
@@ -74,8 +74,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register long *stackref, stsizediff;
+    int err;
+    long *stackref, stsizediff;
     void * toc;
     void * r30;
     __asm__ volatile ("" : : : REGS_TO_SAVE);

--- a/src/greenlet/platform/switch_ppc64_linux.h
+++ b/src/greenlet/platform/switch_ppc64_linux.h
@@ -76,8 +76,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register long *stackref, stsizediff;
+    int err;
+    long *stackref, stsizediff;
     void * toc;
     void * r30;
     __asm__ volatile ("" : : : REGS_TO_SAVE);

--- a/src/greenlet/platform/switch_ppc_aix.h
+++ b/src/greenlet/platform/switch_ppc_aix.h
@@ -53,8 +53,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {

--- a/src/greenlet/platform/switch_ppc_linux.h
+++ b/src/greenlet/platform/switch_ppc_linux.h
@@ -49,8 +49,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {

--- a/src/greenlet/platform/switch_ppc_macosx.h
+++ b/src/greenlet/platform/switch_ppc_macosx.h
@@ -46,8 +46,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ ("; asm block 2\n\tmr %0, r1" : "=g" (stackref) : );
     {

--- a/src/greenlet/platform/switch_ppc_unix.h
+++ b/src/greenlet/platform/switch_ppc_unix.h
@@ -47,8 +47,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ ("mr %0, 1" : "=g" (stackref) : );
     {

--- a/src/greenlet/platform/switch_s390_unix.h
+++ b/src/greenlet/platform/switch_s390_unix.h
@@ -36,8 +36,8 @@
 static int
 slp_switch(void)
 {
-    register int ret;
-    register long *stackref, stsizediff;
+    int ret;
+    long *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
 #ifdef __s390x__
     __asm__ volatile ("lgr %0, 15" : "=r" (stackref) : );

--- a/src/greenlet/platform/switch_sparc_sun_gcc.h
+++ b/src/greenlet/platform/switch_sparc_sun_gcc.h
@@ -51,8 +51,8 @@
 static int
 slp_switch(void)
 {
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
 
     /* Put current stack pointer into stackref.
      * Register spilling is done in save/restore.

--- a/src/greenlet/platform/switch_x32_unix.h
+++ b/src/greenlet/platform/switch_x32_unix.h
@@ -22,8 +22,8 @@ slp_switch(void)
     void* ebx;
     unsigned int csr;
     unsigned short cw;
-    register int err;
-    register int *stackref, stsizediff;
+    int err;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
     __asm__ volatile ("fstcw %0" : "=m" (cw));
     __asm__ volatile ("stmxcsr %0" : "=m" (csr));

--- a/src/greenlet/platform/switch_x86_unix.h
+++ b/src/greenlet/platform/switch_x86_unix.h
@@ -51,7 +51,7 @@ slp_switch(void)
 #endif
     void *ebp, *ebx;
     unsigned short cw;
-    register int *stackref, stsizediff;
+    int *stackref, stsizediff;
     __asm__ volatile ("" : : : "esi", "edi");
     __asm__ volatile ("fstcw %0" : "=m" (cw));
     __asm__ volatile ("movl %%ebp, %0" : "=m" (ebp));


### PR DESCRIPTION
This has been dropped in c++17 and newer

Signed-off-by: Khem Raj <raj.khem@gmail.com>