### PR TITLE
Build wheels for s390x Linux

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -168,6 +168,7 @@ jobs:
           - manylinux2010_x86_64
           - manylinux2014_aarch64
           - manylinux2014_ppc64le
+          - manylinux2014_s390x
           - manylinux2014_x86_64
           - musllinux_1_1_x86_64
           - musllinux_1_1_aarch64
@@ -180,13 +181,10 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Enable emulation
-        run: |
-          docker run --rm --privileged hypriot/qemu-register
-        # This one was seen in pyca/bcrypt. What's the difference?
-        # (Other than this one not working.)
-        #run: |
-        #  docker run --rm --privileged multiarch/qemu-user-static:register --reset
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: all
       - name: Build and test greenlet
         if: matrix.image == 'manylinux2010_x86_64'
         # An alternate way to do this is to run the container directly with a uses:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,12 @@
  Changes
 =========
 
-2.0.3 (unreleased)
+3.0.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Build binary wheels for S390x Linux. See `PR 358
+  <https://github.com/python-greenlet/greenlet/pull/358>`_ from Steven
+  Silvester.
 
 
 2.0.2 (2023-01-28)


### PR DESCRIPTION
Adds support for s390x architecture, using the pattern suggested in [cibuildwheel](https://github.com/pypa/cibuildwheel/blob/0ecddd92b62987d7a2ae8911f4bb8ec9e2e4496a/examples/github-with-qemu.yml).