### PR TITLE
Remove obsolete python and compiler support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,11 +25,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
-        # Jan 2023: We have pinned back from ubuntu-latest (which is
-        # now ubuntu 22.04) because older Python versions like
-        # 3.5, 3.6 and presumably 2.7 are not available in it.
-        os: [ubuntu-20.04, macos-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        os: [ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest
             python-version: 3.12-dev
@@ -95,12 +92,12 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       run: |
         twine upload --skip-existing dist/*
-
+  # XXX: Is non-standard thread mode even needed?
   test_non_standard_thread:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.5, "3.11"]
+        python-version: ["3.11"]
         os: [ubuntu-20.04, macos-latest]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12-dev"]
         os: [ubuntu-latest, macos-latest]
         exclude:
           - os: macos-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,35 +92,6 @@ jobs:
         TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
       run: |
         twine upload --skip-existing dist/*
-  # XXX: Is non-standard thread mode even needed?
-  test_non_standard_thread:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        python-version: ["3.11"]
-        os: [ubuntu-20.04, macos-latest]
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-        cache: 'pip'
-        cache-dependency-path: setup.py
-    - name: Install dependencies
-      run: |
-        python -m pip install -U pip setuptools wheel
-        python -m pip install -U twine
-    - name: Install greenlet
-      env:
-        CPPFLAGS: "-DG_USE_STANDARD_THREADING=0 -UNDEBUG -Ofast"
-      run: |
-        python setup.py bdist_wheel
-        python -m pip install -U -v -e ".[test,docs]"
-    - name: Test
-      run: |
-        python -c 'import greenlet._greenlet as G; assert not G.GREENLET_USE_STANDARD_THREADING'
-        python -m unittest discover -v greenlet.tests
 
   CodeQL:
     runs-on: ubuntu-latest

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@
   raphaelauv, Hugo van Kemenade, Mark Shannon, and Petr Viktorin.
 - Remove support for end-of-life Python versions, including Python
   2.7, Python 3.5 and Python 3.6.
+- Require a compiler that supports ``noinline`` directives. See
+  `issue 271 <https://github.com/python-greenlet/greenlet/issues/266>`_
 
 
 2.0.2 (2023-01-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@
   <https://github.com/python-greenlet/greenlet/pull/327>`_; thanks go
   to (at least) Michael Droettboom, Andreas Motl, Thomas A Caswell,
   raphaelauv, Hugo van Kemenade, Mark Shannon, and Petr Viktorin.
+- Remove support for end-of-life Python versions, including Python 2.7
+  and Python 3.5.
 
 
 2.0.2 (2023-01-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,8 +23,8 @@
   <https://github.com/python-greenlet/greenlet/pull/327>`_; thanks go
   to (at least) Michael Droettboom, Andreas Motl, Thomas A Caswell,
   raphaelauv, Hugo van Kemenade, Mark Shannon, and Petr Viktorin.
-- Remove support for end-of-life Python versions, including Python 2.7
-  and Python 3.5.
+- Remove support for end-of-life Python versions, including Python
+  2.7, Python 3.5 and Python 3.6.
 
 
 2.0.2 (2023-01-28)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,7 +26,9 @@
 - Remove support for end-of-life Python versions, including Python
   2.7, Python 3.5 and Python 3.6.
 - Require a compiler that supports ``noinline`` directives. See
-  `issue 271 <https://github.com/python-greenlet/greenlet/issues/266>`_
+  `issue 271
+  <https://github.com/python-greenlet/greenlet/issues/266>`_.
+- Require a compiler that supports C++11.
 
 
 2.0.2 (2023-01-28)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,17 +39,23 @@ environment:
 
     # Fully supported 64-bit versions, with testing. This should be
     # all the current (non EOL) versions.
+    - PYTHON: "C:\\Python312-x64"
+      PYTHON_VERSION: "3.12.0b3"
+      PYTHON_ARCH: "64"
+      PYTHON_EXE: python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+
     - PYTHON: "C:\\Python311-x64"
       PYTHON_VERSION: "3.11.0"
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
 
     - PYTHON: "C:\\Python310-x64"
       PYTHON_VERSION: "3.10.0"
       PYTHON_ARCH: "64"
       PYTHON_EXE: python
-      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
 
     - PYTHON: "C:\\Python39-x64"
       PYTHON_ARCH: "64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -83,11 +83,7 @@ environment:
     # Untested 64-bit versions. We don't expect any variance here from
     # the other tested 64-bit versions, OR they are very EOL
 
-    - PYTHON: "C:\\Python36-x64"
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
+    # None right now.
 
     # Untested 32-bit versions. As above, we don't expect any variance
     # from the tested 32-bit versions, OR they are very EOL.
@@ -104,11 +100,6 @@ environment:
       PYTHON_EXE: python
       GWHEEL_ONLY: true
 
-    - PYTHON: "C:\\Python36"
-      PYTHON_ARCH: "32"
-      PYTHON_VERSION: "3.6.x"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
 
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,12 +89,6 @@ environment:
       PYTHON_EXE: python
       GWHEEL_ONLY: true
 
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_ARCH: "64"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
-
     # Untested 32-bit versions. As above, we don't expect any variance
     # from the tested 32-bit versions, OR they are very EOL.
 
@@ -115,13 +109,6 @@ environment:
       PYTHON_VERSION: "3.6.x"
       PYTHON_EXE: python
       GWHEEL_ONLY: true
-
-    - PYTHON: "C:\\Python35"
-      PYTHON_ARCH: "32"
-      PYTHON_VERSION: "3.5.x"
-      PYTHON_EXE: python
-      GWHEEL_ONLY: true
-
 
 
 cache:

--- a/make-manylinux
+++ b/make-manylinux
@@ -32,7 +32,7 @@ if [ -d /greenlet -a -d /opt/python ]; then
     mkdir -p /greenlet/wheelhouse
     OPATH="$PATH"
     which auditwheel
-    for variant in `ls -d /opt/python/cp{36,37,38,39,310,311}*`; do
+    for variant in `ls -d /opt/python/cp{37,38,39,310,311,312}*`; do
         export PATH="$variant/bin:$OPATH"
         echo "Building $variant $(python --version)"
 
@@ -53,5 +53,5 @@ fi
 
 # Mount the current directory as /greenlet
 # Can't use -i on Travis with arm64, "input device not a tty"
-docker run --rm -v "$(pwd):/greenlet"  ${DOCKER_IMAGE:-quay.io/pypa/manylinux2010_x86_64} /greenlet/$(basename $0)
+docker run --rm -v "$(pwd):/greenlet"  ${DOCKER_IMAGE:-quay.io/pypa/manylinux2014_x86_64} /greenlet/$(basename $0)
 ls -l wheelhouse

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,6 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
@@ -242,17 +241,12 @@ setup(
     extras_require={
         'docs': [
             'Sphinx',
-            # 0.18b1 breaks sphinx 1.8.5 which is the latest version that runs
-            # on Python 2. The version pin sphinx itself contains isn't specific enough.
-            'docutils < 0.18; python_version < "3"',
         ],
         'test': [
             'objgraph',
-            # Sigh, all releases of this were yanked from PyPI.
-            #'faulthandler; python_version == "2.7" and platform_python_implementation == "CPython"',
             'psutil',
         ],
     },
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     zip_safe=False,
 )

--- a/setup.py
+++ b/setup.py
@@ -229,6 +229,7 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',

--- a/setup.py
+++ b/setup.py
@@ -229,7 +229,6 @@ setup(
         'Programming Language :: C',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -247,6 +246,6 @@ setup(
             'psutil',
         ],
     },
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     zip_safe=False,
 )

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -152,7 +152,7 @@ greenlet::refs::_BorrowedGreenlet<T, TC>& greenlet::refs::_BorrowedGreenlet<T, T
 }
 
 template <typename T, greenlet::refs::TypeChecker TC>
-inline greenlet::refs::_BorrowedGreenlet<T, TC>::operator Greenlet*() const G_NOEXCEPT
+inline greenlet::refs::_BorrowedGreenlet<T, TC>::operator Greenlet*() const noexcept
 {
     if (!this->p) {
         return nullptr;
@@ -169,7 +169,7 @@ greenlet::refs::_BorrowedGreenlet<T, TC>::_BorrowedGreenlet(const BorrowedObject
 }
 
 template <typename T, greenlet::refs::TypeChecker TC>
-inline greenlet::refs::_OwnedGreenlet<T, TC>::operator Greenlet*() const G_NOEXCEPT
+inline greenlet::refs::_OwnedGreenlet<T, TC>::operator Greenlet*() const noexcept
 {
     if (!this->p) {
         return nullptr;
@@ -790,26 +790,26 @@ MainGreenlet::MainGreenlet(PyGreenlet* p, ThreadState* state)
 }
 
 ThreadState*
-MainGreenlet::thread_state() const G_NOEXCEPT
+MainGreenlet::thread_state() const noexcept
 {
     return this->_thread_state;
 }
 
 void
-MainGreenlet::thread_state(ThreadState* t) G_NOEXCEPT
+MainGreenlet::thread_state(ThreadState* t) noexcept
 {
     assert(!t);
     this->_thread_state = t;
 }
 
 BorrowedGreenlet
-UserGreenlet::self() const G_NOEXCEPT
+UserGreenlet::self() const noexcept
 {
     return this->_self;
 }
 
 BorrowedGreenlet
-MainGreenlet::self() const G_NOEXCEPT
+MainGreenlet::self() const noexcept
 {
     return BorrowedGreenlet(this->_self.borrow());
 }
@@ -916,7 +916,7 @@ g_handle_exit(const OwnedObject& greenlet_result);
  * argument dict. Otherwise, we'll create a tuple of (args, kwargs) and
  * return both.
  */
-OwnedObject& operator<<=(OwnedObject& lhs, greenlet::SwitchingArgs& rhs) G_NOEXCEPT
+OwnedObject& operator<<=(OwnedObject& lhs, greenlet::SwitchingArgs& rhs) noexcept
 {
     // Because this may invoke arbitrary Python code, which could
     // result in switching back to us, we need to get the
@@ -1005,7 +1005,7 @@ UserGreenlet::throw_GreenletExit_during_dealloc(const ThreadState& current_threa
 }
 
 ThreadState*
-UserGreenlet::thread_state() const G_NOEXCEPT
+UserGreenlet::thread_state() const noexcept
 {
     // TODO: maybe make this throw, if the thread state isn't there?
     // if (!this->main_greenlet) {
@@ -1020,19 +1020,19 @@ UserGreenlet::thread_state() const G_NOEXCEPT
 
 
 bool
-UserGreenlet::was_running_in_dead_thread() const G_NOEXCEPT
+UserGreenlet::was_running_in_dead_thread() const noexcept
 {
     return this->_main_greenlet && !this->thread_state();
 }
 
 bool
-MainGreenlet::was_running_in_dead_thread() const G_NOEXCEPT
+MainGreenlet::was_running_in_dead_thread() const noexcept
 {
     return !this->_thread_state;
 }
 
 inline void
-Greenlet::slp_restore_state() G_NOEXCEPT
+Greenlet::slp_restore_state() noexcept
 {
 #ifdef SLP_BEFORE_RESTORE_STATE
     SLP_BEFORE_RESTORE_STATE();
@@ -1043,7 +1043,7 @@ Greenlet::slp_restore_state() G_NOEXCEPT
 
 
 inline int
-Greenlet::slp_save_state(char *const stackref) G_NOEXCEPT
+Greenlet::slp_save_state(char *const stackref) noexcept
 {
     // XXX: This used to happen in the middle, before saving, but
     // after finding the next owner. Does that matter? This is
@@ -1175,7 +1175,7 @@ MainGreenlet::g_switch()
 
 
 OwnedGreenlet
-Greenlet::g_switchstack_success() G_NOEXCEPT
+Greenlet::g_switchstack_success() noexcept
 {
     PyThreadState* tstate = PyThreadState_GET();
     // restore the saved state
@@ -1413,7 +1413,7 @@ UserGreenlet::inner_bootstrap(OwnedGreenlet& origin_greenlet, OwnedObject& _run)
             // It gets more complicated than that, though, on some
             // platforms, specifically at least Linux/gcc/libstdc++. They use
             // an exception to unwind the stack when a background
-            // thread exits. (See comments about G_NOEXCEPT.) So this
+            // thread exits. (See comments about noexcept.) So this
             // may not actually represent anything untoward. On those
             // platforms we allow throws of this to propagate, or
             // attempt to anyway.
@@ -3139,10 +3139,9 @@ static struct PyModuleDef greenlet_module_def = {
 
 
 static PyObject*
-greenlet_internal_mod_init() G_NOEXCEPT
+greenlet_internal_mod_init() noexcept
 {
     static void* _PyGreenlet_API[PyGreenlet_API_pointers];
-    GREENLET_NOINLINE_INIT();
 
     try {
         CreatedModule m(greenlet_module_def);

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -318,17 +318,6 @@ public:
     Mutex* const thread_states_to_destroy_lock;
     greenlet::cleanup_queue_t thread_states_to_destroy;
 
-    GreenletGlobals(const int UNUSED(dummy)) :
-        event_switch(0),
-        event_throw(0),
-        PyExc_GreenletError(0),
-        PyExc_GreenletExit(0),
-        empty_tuple(0),
-        empty_dict(0),
-        str_run(0),
-        thread_states_to_destroy_lock(0)
-    {}
-
     GreenletGlobals() :
         event_switch("switch"),
         event_throw("throw"),

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -725,7 +725,7 @@ Greenlet::Greenlet(PyGreenlet* p, const StackState& initial_stack)
     p->pimpl = this;
 }
 
-UserGreenlet::UserGreenlet(PyGreenlet* p,BorrowedGreenlet the_parent)
+UserGreenlet::UserGreenlet(PyGreenlet* p, BorrowedGreenlet the_parent)
     : Greenlet(p), _parent(the_parent)
 {
     this->_self = p;
@@ -3188,20 +3188,14 @@ greenlet_internal_mod_init() noexcept
 }
 
 extern "C" {
-#if PY_MAJOR_VERSION >= 3
+
 PyMODINIT_FUNC
 PyInit__greenlet(void)
 {
     return greenlet_internal_mod_init();
 }
-#else
-PyMODINIT_FUNC
-init_greenlet(void)
-{
-    greenlet_internal_mod_init();
-}
-#endif
-};
+
+}; // extern C
 
 #ifdef __clang__
 #    pragma clang diagnostic pop

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -46,7 +46,6 @@
 #  define G_FP_TMPL_STATIC
 # endif
 
-
 #    define G_NO_COPIES_OF_CLS(Cls) private:     \
     Cls(const Cls& other) = delete; \
     Cls& operator=(const Cls& other) = delete

--- a/src/greenlet/greenlet_compiler_compat.hpp
+++ b/src/greenlet/greenlet_compiler_compat.hpp
@@ -5,11 +5,11 @@
 /**
  * Definitions to aid with compatibility with different compilers.
  *
- * .. caution:: Use extreme care with G_NOEXCEPT.
+ * .. caution:: Use extreme care with noexcept.
  * Some compilers and runtimes, specifically gcc/libgcc/libstdc++ on
  * Linux, implement stack unwinding by throwing an uncatchable
  * exception, one that specifically does not appear to be an active
- * exception to the rest of the runtime. If this happens while we're in a G_NOEXCEPT function,
+ * exception to the rest of the runtime. If this happens while we're in a noexcept function,
  * we have violated our dynamic exception contract, and so the runtime
  * will call std::terminate(), which kills the process with the
  * unhelpful message "terminate called without an active exception".
@@ -21,7 +21,7 @@
  * attempts to obtain the  GIL, it notices that the interpreter is
  * exiting and calls ``pthread_exit()``. This in turn starts to unwind
  * the stack by throwing that exception. But we had the ``PyCall``
- * functions annotated as G_NOEXCEPT, so the runtime terminated us.
+ * functions annotated as noexcept, so the runtime terminated us.
  *
  * #2  0x00007fab26fec2b7 in std::terminate() () from /lib/x86_64-linux-gnu/libstdc++.so.6
  * #3  0x00007fab26febb3c in __gxx_personality_v0 () from /lib/x86_64-linux-gnu/libstdc++.so.6
@@ -36,34 +36,8 @@
  * #13 0x00000000006101cd in socket_gethostbyname
  */
 
-
-/* The compiler used for Python 2.7 on Windows doesn't include
-   either stdint.h or cstdint.h. Nor does it understand nullptr or have
-   std::shared_ptr. = delete, etc Sigh. */
-#if defined(_MSC_VER) &&  _MSC_VER <= 1500
-typedef unsigned long long uint64_t;
-typedef signed long long int64_t;
-typedef unsigned int uint32_t;
-// C++ defines NULL to be 0, which is ambiguous
-// with an integer in certain cases, and won't autoconvert to a
-// pointer in other cases.
-#define nullptr NULL
-#define G_HAS_METHOD_DELETE 0
-// Use G_EXPLICIT_OP as the prefix for operator methods
-// that should be explicit. Old MSVC doesn't support explicit operator
-// methods.
-#define G_EXPLICIT_OP
-#define G_NOEXCEPT throw()
-// This version doesn't support "objects with internal linkage"
-// in non-type template arguments. Translation: function pointer
-// template arguments cannot be for static functions.
-#define G_FP_TMPL_STATIC
-#else
-// Newer, reasonable compilers implementing C++11 or so.
 #include <cstdint>
-#define G_HAS_METHOD_DELETE 1
-#define G_EXPLICIT_OP explicit
-#define G_NOEXCEPT noexcept
+
 # if defined(__clang__)
 #  define G_FP_TMPL_STATIC static
 # else
@@ -72,9 +46,7 @@ typedef unsigned int uint32_t;
 #  define G_FP_TMPL_STATIC
 # endif
 
-#endif
 
-#if G_HAS_METHOD_DELETE == 1
 #    define G_NO_COPIES_OF_CLS(Cls) private:     \
     Cls(const Cls& other) = delete; \
     Cls& operator=(const Cls& other) = delete
@@ -84,17 +56,7 @@ typedef unsigned int uint32_t;
 
 #    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) private: \
     Cls(const Cls& other) = delete;
-#else
-#    define G_NO_COPIES_OF_CLS(Cls) private: \
-    Cls(const Cls& other); \
-    Cls& operator=(const Cls& other)
 
-#    define G_NO_ASSIGNMENT_OF_CLS(Cls) private: \
-        Cls& operator=(const Cls& other)
-
-#    define G_NO_COPY_CONSTRUCTOR_OF_CLS(Cls) private: \
-    Cls(const Cls& other);
-#endif
 
 // CAUTION: MSVC is stupidly picky:
 //
@@ -106,24 +68,26 @@ typedef unsigned int uint32_t;
 // So pointer return types must be handled differently (because of the
 // trailing *), or you get inscrutable compiler warnings like "error
 // C2059: syntax error: ''"
+//
+// In C++ 11, there is a standard syntax for attributes, and
+// GCC defines an attribute to use with this: [[gnu:noinline]].
+// In the future, this is expected to become standard.
 
 #if defined(__GNUC__) || defined(__clang__)
 /* We used to check for GCC 4+ or 3.4+, but those compilers are
    laughably out of date. Just assume they support it. */
-#    define GREENLET_NOINLINE_SUPPORTED
 #    define GREENLET_NOINLINE(name) __attribute__((noinline)) name
 #    define GREENLET_NOINLINE_P(rtype, name) rtype __attribute__((noinline)) name
 #    define UNUSED(x) UNUSED_ ## x __attribute__((__unused__))
 #elif defined(_MSC_VER)
 /* We used to check for  && (_MSC_VER >= 1300) but that's also out of date. */
-#    define GREENLET_NOINLINE_SUPPORTED
 #    define GREENLET_NOINLINE(name) __declspec(noinline) name
 #    define GREENLET_NOINLINE_P(rtype, name) __declspec(noinline) rtype name
 #    define UNUSED(x) UNUSED_ ## x
 #endif
 
 #if defined(_MSC_VER)
-#    define G_NOEXCEPT_WIN32 G_NOEXCEPT
+#    define G_NOEXCEPT_WIN32 noexcept
 #else
 #    define G_NOEXCEPT_WIN32
 #endif

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -9,33 +9,6 @@
 #define PY_SSIZE_T_CLEAN
 #include "Python.h"
 
-// These enable writing template functions or classes specialized
-// based on the Python version. Write both versions of the function,
-// one with the WHEN version, one with the WHEN_NOT version.
-// Instantiate the template using the G_IS_PY37 macro.
-struct GREENLET_WHEN_PY37
-{
-    typedef GREENLET_WHEN_PY37* Yes;
-    // We really just want an alias, `using Yes = IsIt`,
-    // but old MSVC for Py27 doesn't support that.
-    typedef GREENLET_WHEN_PY37* IsIt;
-};
-
-struct GREENLET_WHEN_NOT_PY37
-{
-    typedef GREENLET_WHEN_NOT_PY37* No;
-    typedef GREENLET_WHEN_NOT_PY37* IsIt;
-};
-
-
-#if PY_VERSION_HEX >= 0x030700A3
-#    define GREENLET_PY37 1
-typedef GREENLET_WHEN_PY37 G_IS_PY37;
-#else
-#    define GREENLET_PY37 0
-typedef GREENLET_WHEN_NOT_PY37 G_IS_PY37;
-#endif
-
 
 #if PY_VERSION_HEX >= 0x30A00B1
 /*
@@ -48,11 +21,7 @@ We have to save and restore this as well.
 #    define GREENLET_USE_CFRAME 0
 #endif
 
-#if PY_VERSION_HEX >= 0x30C0000
-#    define GREENLET_PY312 1
-#else
-#    define GREENLET_PY312 0
-#endif
+
 
 #if PY_VERSION_HEX >= 0x30B00A4
 /*
@@ -70,6 +39,13 @@ https://bugs.python.org/issue46090). Summary of breaking internal changes:
 #    define GREENLET_PY311 1
 #else
 #    define GREENLET_PY311 0
+#endif
+
+
+#if PY_VERSION_HEX >= 0x30C0000
+#    define GREENLET_PY312 1
+#else
+#    define GREENLET_PY312 0
 #endif
 
 #ifndef Py_SET_REFCNT
@@ -98,47 +74,19 @@ https://bugs.python.org/issue39573 */
 #ifndef Py_TPFLAGS_HAVE_NEWBUFFER
   #define Py_TPFLAGS_HAVE_NEWBUFFER 0
 #endif
-#ifndef Py_TPFLAGS_HAVE_FINALIZE
-  #define Py_TPFLAGS_HAVE_FINALIZE 0
-#endif
+
 #ifndef Py_TPFLAGS_HAVE_VERSION_TAG
    #define Py_TPFLAGS_HAVE_VERSION_TAG 0
 #endif
 
 #define G_TPFLAGS_DEFAULT Py_TPFLAGS_DEFAULT | Py_TPFLAGS_HAVE_VERSION_TAG | Py_TPFLAGS_CHECKTYPES | Py_TPFLAGS_HAVE_NEWBUFFER | Py_TPFLAGS_HAVE_GC
 
-#if PY_MAJOR_VERSION >= 3
-#    define GNative_FromFormat PyUnicode_FromFormat
-#else
-#    define GNative_FromFormat PyString_FromFormat
-#endif
-
-#if PY_MAJOR_VERSION >= 3
-#    define Greenlet_Intern PyUnicode_InternFromString
-#else
-#    define Greenlet_Intern PyString_InternFromString
-#endif
 
 #if PY_VERSION_HEX < 0x03090000
 // The official version only became available in 3.9
 #    define PyObject_GC_IsTracked(o) _PyObject_GC_IS_TRACKED(o)
 #endif
 
-#if PY_MAJOR_VERSION < 3
-struct PyModuleDef {
-    int unused;
-    const char* const m_name;
-    const char* m_doc;
-    Py_ssize_t m_size;
-    PyMethodDef* m_methods;
-    // Then several more fields we're not currently using.
-};
-#define PyModuleDef_HEAD_INIT 1
-PyObject* PyModule_Create(PyModuleDef* m)
-{
-    return Py_InitModule(m->m_name, m->m_methods);
-}
-#endif
 
 // bpo-43760 added PyThreadState_EnterTracing() to Python 3.11.0a2
 #if PY_VERSION_HEX < 0x030B00A2 && !defined(PYPY_VERSION)

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -928,6 +928,10 @@ void PythonState::set_initial_state(const PyThreadState* const tstate) noexcept
     this->_top_frame = nullptr;
 #if GREENLET_PY312
     this->py_recursion_depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;
+    // XXX: TODO: Comment from a reviewer:
+    //     Should this be ``C_RECURSION_LIMIT - tstate->c_recursion_remaining``?
+    // But to me it looks more like that might not be the right
+    // initialization either?
     this->c_recursion_depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;
 #elif GREENLET_PY311
     this->recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -48,12 +48,12 @@ namespace greenlet
 #endif
     public:
         ExceptionState();
-        void operator<<(const PyThreadState *const tstate) G_NOEXCEPT;
-        void operator>>(PyThreadState* tstate) G_NOEXCEPT;
-        void clear() G_NOEXCEPT;
+        void operator<<(const PyThreadState *const tstate) noexcept;
+        void operator>>(PyThreadState* tstate) noexcept;
+        void clear() noexcept;
 
-        int tp_traverse(visitproc visit, void* arg) G_NOEXCEPT;
-        void tp_clear() G_NOEXCEPT;
+        int tp_traverse(visitproc visit, void* arg) noexcept;
+        void tp_clear() noexcept;
     };
 
     template<typename T>
@@ -161,21 +161,21 @@ namespace greenlet
         PythonState();
         // You can use this for testing whether we have a frame
         // or not. It returns const so they can't modify it.
-        const OwnedFrame& top_frame() const G_NOEXCEPT;
+        const OwnedFrame& top_frame() const noexcept;
 
 
-        void operator<<(const PyThreadState *const tstate) G_NOEXCEPT;
-        void operator>>(PyThreadState* tstate) G_NOEXCEPT;
-        void clear() G_NOEXCEPT;
+        void operator<<(const PyThreadState *const tstate) noexcept;
+        void operator>>(PyThreadState* tstate) noexcept;
+        void clear() noexcept;
 
-        int tp_traverse(visitproc visit, void* arg, bool visit_top_frame) G_NOEXCEPT;
-        void tp_clear(bool own_top_frame) G_NOEXCEPT;
-        void set_initial_state(const PyThreadState* const tstate) G_NOEXCEPT;
+        int tp_traverse(visitproc visit, void* arg, bool visit_top_frame) noexcept;
+        void tp_clear(bool own_top_frame) noexcept;
+        void set_initial_state(const PyThreadState* const tstate) noexcept;
 #if GREENLET_USE_CFRAME
-        void set_new_cframe(_PyCFrame& frame) G_NOEXCEPT;
+        void set_new_cframe(_PyCFrame& frame) noexcept;
 #endif
-        void will_switch_from(PyThreadState *const origin_tstate) G_NOEXCEPT;
-        void did_finish(PyThreadState* tstate) G_NOEXCEPT;
+        void will_switch_from(PyThreadState *const origin_tstate) noexcept;
+        void did_finish(PyThreadState* tstate) noexcept;
     };
 
     class StackState
@@ -193,8 +193,8 @@ namespace greenlet
         char* stack_copy;
         intptr_t _stack_saved;
         StackState* stack_prev;
-        inline int copy_stack_to_heap_up_to(const char* const stop) G_NOEXCEPT;
-        inline void free_stack_copy() G_NOEXCEPT;
+        inline int copy_stack_to_heap_up_to(const char* const stop) noexcept;
+        inline void free_stack_copy() noexcept;
 
     public:
         /**
@@ -209,16 +209,16 @@ namespace greenlet
         ~StackState();
         StackState(const StackState& other);
         StackState& operator=(const StackState& other);
-        inline void copy_heap_to_stack(const StackState& current) G_NOEXCEPT;
-        inline int copy_stack_to_heap(char* const stackref, const StackState& current) G_NOEXCEPT;
-        inline bool started() const G_NOEXCEPT;
-        inline bool main() const G_NOEXCEPT;
-        inline bool active() const G_NOEXCEPT;
-        inline void set_active() G_NOEXCEPT;
-        inline void set_inactive() G_NOEXCEPT;
-        inline intptr_t stack_saved() const G_NOEXCEPT;
-        inline char* stack_start() const G_NOEXCEPT;
-        static inline StackState make_main() G_NOEXCEPT;
+        inline void copy_heap_to_stack(const StackState& current) noexcept;
+        inline int copy_stack_to_heap(char* const stackref, const StackState& current) noexcept;
+        inline bool started() const noexcept;
+        inline bool main() const noexcept;
+        inline bool active() const noexcept;
+        inline void set_active() noexcept;
+        inline void set_inactive() noexcept;
+        inline intptr_t stack_saved() const noexcept;
+        inline char* stack_start() const noexcept;
+        static inline StackState make_main() noexcept;
 #ifdef GREENLET_USE_STDIO
         friend std::ostream& operator<<(std::ostream& os, const StackState& s);
 #endif
@@ -298,7 +298,7 @@ namespace greenlet
             return *this;
         }
 
-        G_EXPLICIT_OP operator bool() const G_NOEXCEPT
+        explicit operator bool() const noexcept
         {
             return this->_args || this->_kwargs;
         }
@@ -347,7 +347,7 @@ namespace greenlet
 
         virtual const refs::BorrowedMainGreenlet main_greenlet() const = 0;
 
-        inline intptr_t stack_saved() const G_NOEXCEPT
+        inline intptr_t stack_saved() const noexcept
         {
             return this->stack_state.stack_saved();
         }
@@ -357,7 +357,7 @@ namespace greenlet
         // computation ourself, but the type of the result
         // varies by platform, so doing it in the macro is the
         // simplest way.
-        inline const char* stack_start() const G_NOEXCEPT
+        inline const char* stack_start() const noexcept
         {
             return this->stack_state.stack_start();
         }
@@ -391,8 +391,8 @@ namespace greenlet
         void deallocing_greenlet_in_thread(const ThreadState* current_state);
 
         // TODO: Figure out how to make these non-public.
-        inline void slp_restore_state() G_NOEXCEPT;
-        inline int slp_save_state(char *const stackref) G_NOEXCEPT;
+        inline void slp_restore_state() noexcept;
+        inline int slp_save_state(char *const stackref) noexcept;
 
         inline bool is_currently_running_in_some_thread() const;
         virtual bool belongs_to_thread(const ThreadState* state) const;
@@ -430,15 +430,15 @@ namespace greenlet
         // Return the thread state that the greenlet is running in, or
         // null if the greenlet is not running or the thread is known
         // to have exited.
-        virtual ThreadState* thread_state() const G_NOEXCEPT = 0;
+        virtual ThreadState* thread_state() const noexcept = 0;
 
         // Return true if the greenlet is known to have been running
         // (active) in a thread that has now exited.
-        virtual bool was_running_in_dead_thread() const G_NOEXCEPT = 0;
+        virtual bool was_running_in_dead_thread() const noexcept = 0;
 
         // Return a borrowed greenlet that is the Python object
         // this object represents.
-        virtual BorrowedGreenlet self() const G_NOEXCEPT = 0;
+        virtual BorrowedGreenlet self() const noexcept = 0;
 
     protected:
         inline void release_args();
@@ -492,7 +492,7 @@ namespace greenlet
         };
 
         // Returns the previous greenlet we just switched away from.
-        virtual OwnedGreenlet g_switchstack_success() G_NOEXCEPT;
+        virtual OwnedGreenlet g_switchstack_success() noexcept;
 
 
         // Check the preconditions for switching to this greenlet; if they
@@ -563,8 +563,8 @@ namespace greenlet
         virtual ~UserGreenlet();
 
         virtual refs::BorrowedMainGreenlet find_main_greenlet_in_lineage() const;
-        virtual bool was_running_in_dead_thread() const G_NOEXCEPT;
-        virtual ThreadState* thread_state() const G_NOEXCEPT;
+        virtual bool was_running_in_dead_thread() const noexcept;
+        virtual ThreadState* thread_state() const noexcept;
         virtual OwnedObject g_switch();
         virtual const OwnedObject& run() const
         {
@@ -580,7 +580,7 @@ namespace greenlet
 
         virtual const refs::BorrowedMainGreenlet main_greenlet() const;
 
-        virtual BorrowedGreenlet self() const G_NOEXCEPT;
+        virtual BorrowedGreenlet self() const noexcept;
         virtual void murder_in_place();
         virtual bool belongs_to_thread(const ThreadState* state) const;
         virtual int tp_traverse(visitproc visit, void* arg);
@@ -626,11 +626,11 @@ namespace greenlet
         virtual const refs::BorrowedMainGreenlet main_greenlet() const;
 
         virtual refs::BorrowedMainGreenlet find_main_greenlet_in_lineage() const;
-        virtual bool was_running_in_dead_thread() const G_NOEXCEPT;
-        virtual ThreadState* thread_state() const G_NOEXCEPT;
-        void thread_state(ThreadState*) G_NOEXCEPT;
+        virtual bool was_running_in_dead_thread() const noexcept;
+        virtual ThreadState* thread_state() const noexcept;
+        void thread_state(ThreadState*) noexcept;
         virtual OwnedObject g_switch();
-        virtual BorrowedGreenlet self() const G_NOEXCEPT;
+        virtual BorrowedGreenlet self() const noexcept;
         virtual int tp_traverse(visitproc visit, void* arg);
     };
 
@@ -651,13 +651,13 @@ ExceptionState::ExceptionState()
 
 #if PY_VERSION_HEX >= 0x030700A3
 // ******** Python 3.7 and above *********
-void ExceptionState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+void ExceptionState::operator<<(const PyThreadState *const tstate) noexcept
 {
     this->exc_info = tstate->exc_info;
     this->exc_state = tstate->exc_state;
 }
 
-void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+void ExceptionState::operator>>(PyThreadState *const tstate) noexcept
 {
     tstate->exc_state = this->exc_state;
     tstate->exc_info =
@@ -665,7 +665,7 @@ void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
     this->clear();
 }
 
-void ExceptionState::clear() G_NOEXCEPT
+void ExceptionState::clear() noexcept
 {
     this->exc_info = nullptr;
     this->exc_state.exc_value = nullptr;
@@ -676,7 +676,7 @@ void ExceptionState::clear() G_NOEXCEPT
     this->exc_state.previous_item = nullptr;
 }
 
-int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
+int ExceptionState::tp_traverse(visitproc visit, void* arg) noexcept
 {
     Py_VISIT(this->exc_state.exc_value);
 #if !GREENLET_PY311
@@ -686,7 +686,7 @@ int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
     return 0;
 }
 
-void ExceptionState::tp_clear() G_NOEXCEPT
+void ExceptionState::tp_clear() noexcept
 {
     Py_CLEAR(this->exc_state.exc_value);
 #if !GREENLET_PY311
@@ -696,7 +696,7 @@ void ExceptionState::tp_clear() G_NOEXCEPT
 }
 #else
 // ********** Python 3.6 and below ********
-void ExceptionState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+void ExceptionState::operator<<(const PyThreadState *const tstate) noexcept
 {
     this->exc_value.steal(tstate->exc_value);
 #if !GREENLET_PY311
@@ -705,7 +705,7 @@ void ExceptionState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
 #endif
 }
 
-void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+void ExceptionState::operator>>(PyThreadState *const tstate) noexcept
 {
     tstate->exc_value <<= this->exc_value;
 #if !GREENLET_PY311
@@ -715,7 +715,7 @@ void ExceptionState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
     this->clear();
 }
 
-void ExceptionState::clear() G_NOEXCEPT
+void ExceptionState::clear() noexcept
 {
     this->exc_value = nullptr;
 #if !GREENLET_PY311
@@ -724,7 +724,7 @@ void ExceptionState::clear() G_NOEXCEPT
 #endif
 }
 
-int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
+int ExceptionState::tp_traverse(visitproc visit, void* arg) noexcept
 {
     Py_VISIT(this->exc_value.borrow());
 #if !GREENLET_PY311
@@ -734,7 +734,7 @@ int ExceptionState::tp_traverse(visitproc visit, void* arg) G_NOEXCEPT
     return 0;
 }
 
-void ExceptionState::tp_clear() G_NOEXCEPT
+void ExceptionState::tp_clear() noexcept
 {
     this->exc_value.CLEAR();
 #if !GREENLET_PY311
@@ -821,7 +821,7 @@ PythonState::PythonState()
 #endif
 }
 
-void PythonState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
+void PythonState::operator<<(const PyThreadState *const tstate) noexcept
 {
 #if GREENLET_PY37
     this->_context.steal(tstate->context);
@@ -868,7 +868,7 @@ void PythonState::operator<<(const PyThreadState *const tstate) G_NOEXCEPT
 #endif
 }
 
-void PythonState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
+void PythonState::operator>>(PyThreadState *const tstate) noexcept
 {
 #if GREENLET_PY37
     tstate->context = this->_context.relinquish_ownership();
@@ -912,7 +912,7 @@ void PythonState::operator>>(PyThreadState *const tstate) G_NOEXCEPT
 #endif
 }
 
-void PythonState::will_switch_from(PyThreadState *const origin_tstate) G_NOEXCEPT
+void PythonState::will_switch_from(PyThreadState *const origin_tstate) noexcept
 {
 #if GREENLET_USE_CFRAME && !GREENLET_PY312
     // The weird thing is, we don't actually save this for an
@@ -923,7 +923,7 @@ void PythonState::will_switch_from(PyThreadState *const origin_tstate) G_NOEXCEP
 #endif
 }
 
-void PythonState::set_initial_state(const PyThreadState* const tstate) G_NOEXCEPT
+void PythonState::set_initial_state(const PyThreadState* const tstate) noexcept
 {
     this->_top_frame = nullptr;
 #if GREENLET_PY312
@@ -936,7 +936,7 @@ void PythonState::set_initial_state(const PyThreadState* const tstate) G_NOEXCEP
 #endif
 }
 // TODO: Better state management about when we own the top frame.
-int PythonState::tp_traverse(visitproc visit, void* arg, bool own_top_frame) G_NOEXCEPT
+int PythonState::tp_traverse(visitproc visit, void* arg, bool own_top_frame) noexcept
 {
 #if GREENLET_PY37
     Py_VISIT(this->_context.borrow());
@@ -947,7 +947,7 @@ int PythonState::tp_traverse(visitproc visit, void* arg, bool own_top_frame) G_N
     return 0;
 }
 
-void PythonState::tp_clear(bool own_top_frame) G_NOEXCEPT
+void PythonState::tp_clear(bool own_top_frame) noexcept
 {
     PythonStateContext::tp_clear();
     // If we get here owning a frame,
@@ -959,7 +959,7 @@ void PythonState::tp_clear(bool own_top_frame) G_NOEXCEPT
 }
 
 #if GREENLET_USE_CFRAME
-void PythonState::set_new_cframe(_PyCFrame& frame) G_NOEXCEPT
+void PythonState::set_new_cframe(_PyCFrame& frame) noexcept
 {
     frame = *PyThreadState_GET()->cframe;
     /* Make the target greenlet refer to the stack value. */
@@ -972,12 +972,12 @@ void PythonState::set_new_cframe(_PyCFrame& frame) G_NOEXCEPT
 }
 #endif
 
-const PythonState::OwnedFrame& PythonState::top_frame() const G_NOEXCEPT
+const PythonState::OwnedFrame& PythonState::top_frame() const noexcept
 {
     return this->_top_frame;
 }
 
-void PythonState::did_finish(PyThreadState* tstate) G_NOEXCEPT
+void PythonState::did_finish(PyThreadState* tstate) noexcept
 {
 #if GREENLET_PY311
     // See https://github.com/gevent/gevent/issues/1924 and
@@ -1134,14 +1134,14 @@ StackState& StackState::operator=(const StackState& other)
     return *this;
 }
 
-inline void StackState::free_stack_copy() G_NOEXCEPT
+inline void StackState::free_stack_copy() noexcept
 {
     PyMem_Free(this->stack_copy);
     this->stack_copy = nullptr;
     this->_stack_saved = 0;
 }
 
-inline void StackState::copy_heap_to_stack(const StackState& current) G_NOEXCEPT
+inline void StackState::copy_heap_to_stack(const StackState& current) noexcept
 {
     // cerr << "copy_heap_to_stack" << endl
     //      << "\tFrom    : " << *this << endl
@@ -1164,7 +1164,7 @@ inline void StackState::copy_heap_to_stack(const StackState& current) G_NOEXCEPT
     // cerr << "\tFinished with: " << *this << endl;
 }
 
-inline int StackState::copy_stack_to_heap_up_to(const char* const stop) G_NOEXCEPT
+inline int StackState::copy_stack_to_heap_up_to(const char* const stop) noexcept
 {
     /* Save more of g's stack into the heap -- at least up to 'stop'
        g->stack_stop |________|
@@ -1193,7 +1193,7 @@ inline int StackState::copy_stack_to_heap_up_to(const char* const stop) G_NOEXCE
 }
 
 inline int StackState::copy_stack_to_heap(char* const stackref,
-                                          const StackState& current) G_NOEXCEPT
+                                          const StackState& current) noexcept
 {
     // cerr << "copy_stack_to_heap: " << endl
     //      << "\tstackref: " << (void*)stackref << endl
@@ -1229,28 +1229,28 @@ inline int StackState::copy_stack_to_heap(char* const stackref,
     return 0;
 }
 
-inline bool StackState::started() const G_NOEXCEPT
+inline bool StackState::started() const noexcept
 {
     return this->stack_stop != nullptr;
 }
 
-inline bool StackState::main() const G_NOEXCEPT
+inline bool StackState::main() const noexcept
 {
     return this->stack_stop == (char*)-1;
 }
 
-inline bool StackState::active() const G_NOEXCEPT
+inline bool StackState::active() const noexcept
 {
     return this->_stack_start != nullptr;
 }
 
-inline void StackState::set_active() G_NOEXCEPT
+inline void StackState::set_active() noexcept
 {
     assert(this->_stack_start == nullptr);
     this->_stack_start = (char*)1;
 }
 
-inline void StackState::set_inactive() G_NOEXCEPT
+inline void StackState::set_inactive() noexcept
 {
     this->_stack_start = nullptr;
     // XXX: What if we still have memory out there?
@@ -1268,18 +1268,18 @@ inline void StackState::set_inactive() G_NOEXCEPT
     }
 }
 
-inline intptr_t StackState::stack_saved() const G_NOEXCEPT
+inline intptr_t StackState::stack_saved() const noexcept
 {
     return this->_stack_saved;
 }
 
-inline char* StackState::stack_start() const G_NOEXCEPT
+inline char* StackState::stack_start() const noexcept
 {
     return this->_stack_start;
 }
 
 
-inline StackState StackState::make_main() G_NOEXCEPT
+inline StackState StackState::make_main() noexcept
 {
     StackState s;
     s._stack_start = (char*)1;

--- a/src/greenlet/greenlet_internal.hpp
+++ b/src/greenlet/greenlet_internal.hpp
@@ -68,13 +68,13 @@ greenlet::refs::MainGreenletExactChecker(void *p)
 
 
 template <typename T, greenlet::refs::TypeChecker TC>
-inline greenlet::Greenlet* greenlet::refs::_OwnedGreenlet<T, TC>::operator->() const G_NOEXCEPT
+inline greenlet::Greenlet* greenlet::refs::_OwnedGreenlet<T, TC>::operator->() const noexcept
 {
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }
 
 template <typename T, greenlet::refs::TypeChecker TC>
-inline greenlet::Greenlet* greenlet::refs::_BorrowedGreenlet<T, TC>::operator->() const G_NOEXCEPT
+inline greenlet::Greenlet* greenlet::refs::_BorrowedGreenlet<T, TC>::operator->() const noexcept
 {
     return reinterpret_cast<PyGreenlet*>(this->p)->pimpl;
 }

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -178,51 +178,51 @@ namespace greenlet {
         // TODO: This should probably not exist here, but be moved
         // down to relevant sub-types.
 
-        inline T* borrow() const G_NOEXCEPT
+        inline T* borrow() const noexcept
         {
             return this->p;
         }
 
-        PyObject* borrow_o() const G_NOEXCEPT
+        PyObject* borrow_o() const noexcept
         {
             return reinterpret_cast<PyObject*>(this->p);
         }
 
-        inline T* operator->() const G_NOEXCEPT
+        inline T* operator->() const noexcept
         {
             return this->p;
         }
 
-        bool is_None() const G_NOEXCEPT
+        bool is_None() const noexcept
         {
             return this->p == Py_None;
         }
 
-        inline PyObject* acquire_or_None() const G_NOEXCEPT
+        inline PyObject* acquire_or_None() const noexcept
         {
             PyObject* result = this->p ? reinterpret_cast<PyObject*>(this->p) : Py_None;
             Py_INCREF(result);
             return result;
         }
 
-        G_EXPLICIT_OP operator bool() const G_NOEXCEPT
+        explicit operator bool() const noexcept
         {
             return p != nullptr;
         }
 
-        inline Py_ssize_t REFCNT() const G_NOEXCEPT
+        inline Py_ssize_t REFCNT() const noexcept
         {
             return p ? Py_REFCNT(p) : -42;
         }
 
-        inline PyTypeObject* TYPE() const G_NOEXCEPT
+        inline PyTypeObject* TYPE() const noexcept
         {
             return p ? Py_TYPE(p) : nullptr;
         }
 
-        inline OwnedObject PyStr() const G_NOEXCEPT;
-        inline const std::string as_str() const G_NOEXCEPT;
-        inline OwnedObject PyGetAttr(const ImmortalObject& name) const G_NOEXCEPT;
+        inline OwnedObject PyStr() const noexcept;
+        inline const std::string as_str() const noexcept;
+        inline OwnedObject PyGetAttr(const ImmortalObject& name) const noexcept;
         inline OwnedObject PyRequireAttr(const char* const name) const;
         inline OwnedObject PyRequireAttr(const ImmortalObject& name) const;
         inline OwnedObject PyCall(const BorrowedObject& arg) const;
@@ -262,20 +262,20 @@ namespace greenlet {
 #endif
 
     template<typename T, TypeChecker TC>
-    inline bool operator==(const PyObjectPointer<T, TC>& lhs, const void* const rhs) G_NOEXCEPT
+    inline bool operator==(const PyObjectPointer<T, TC>& lhs, const void* const rhs) noexcept
     {
         return lhs.borrow_o() == rhs;
     }
 
     template<typename T, TypeChecker TC, typename X, TypeChecker XC>
-    inline bool operator==(const PyObjectPointer<T, TC>& lhs, const PyObjectPointer<X, XC>& rhs) G_NOEXCEPT
+    inline bool operator==(const PyObjectPointer<T, TC>& lhs, const PyObjectPointer<X, XC>& rhs) noexcept
     {
         return lhs.borrow_o() == rhs.borrow_o();
     }
 
     template<typename T, TypeChecker TC, typename X, TypeChecker XC>
     inline bool operator!=(const PyObjectPointer<T, TC>& lhs,
-                           const PyObjectPointer<X, XC>& rhs) G_NOEXCEPT
+                           const PyObjectPointer<X, XC>& rhs) noexcept
     {
         return lhs.borrow_o() != rhs.borrow_o();
     }
@@ -508,8 +508,8 @@ namespace greenlet {
             return reinterpret_cast<PyObject*>(relinquish_ownership());
         }
 
-        inline Greenlet* operator->() const G_NOEXCEPT;
-        inline operator Greenlet*() const G_NOEXCEPT;
+        inline Greenlet* operator->() const noexcept;
+        inline operator Greenlet*() const noexcept;
     };
 
     template <typename T=PyObject, TypeChecker TC=NoOpChecker>
@@ -564,8 +564,8 @@ namespace greenlet {
         {
             return reinterpret_cast<PyObject*>(this->p);
         }
-        inline Greenlet* operator->() const G_NOEXCEPT;
-        inline operator Greenlet*() const G_NOEXCEPT;
+        inline Greenlet* operator->() const noexcept;
+        inline operator Greenlet*() const noexcept;
     };
 
     typedef _BorrowedGreenlet<PyGreenlet> BorrowedGreenlet;
@@ -655,7 +655,7 @@ namespace greenlet {
     };
 
     template<typename T, TypeChecker TC>
-    inline OwnedObject PyObjectPointer<T, TC>::PyStr() const G_NOEXCEPT
+    inline OwnedObject PyObjectPointer<T, TC>::PyStr() const noexcept
     {
         if (!this->p) {
             return OwnedObject();
@@ -664,7 +664,7 @@ namespace greenlet {
     }
 
     template<typename T, TypeChecker TC>
-    inline const std::string PyObjectPointer<T, TC>::as_str() const G_NOEXCEPT
+    inline const std::string PyObjectPointer<T, TC>::as_str() const noexcept
     {
         // NOTE: This is not Python exception safe.
         if (this->p) {
@@ -685,7 +685,7 @@ namespace greenlet {
     }
 
     template<typename T, TypeChecker TC>
-    inline OwnedObject PyObjectPointer<T, TC>::PyGetAttr(const ImmortalObject& name) const G_NOEXCEPT
+    inline OwnedObject PyObjectPointer<T, TC>::PyGetAttr(const ImmortalObject& name) const noexcept
     {
         assert(this->p);
         return OwnedObject::consuming(PyObject_GetAttr(reinterpret_cast<PyObject*>(this->p), name));

--- a/src/greenlet/greenlet_refs.hpp
+++ b/src/greenlet/greenlet_refs.hpp
@@ -98,13 +98,11 @@ namespace greenlet
             if (!p) {
                 return;
             }
-#if GREENLET_PY37
             if (!PyContext_CheckExact(p)) {
                 throw TypeError(
                     "greenlet context must be a contextvars.Context or None"
                 );
             }
-#endif
         }
 
         typedef OwnedReference<PyObject, ContextExactChecker> OwnedContext;
@@ -635,7 +633,7 @@ namespace greenlet {
         const char* str;
     public:
         ImmortalString(const char* const str) :
-            ImmortalObject(str ? Require(Greenlet_Intern(str)) : nullptr)
+            ImmortalObject(str ? Require(PyUnicode_InternFromString(str)) : nullptr)
         {
             this->str = str;
         }
@@ -643,7 +641,7 @@ namespace greenlet {
         inline ImmortalString& operator=(const char* const str)
         {
             if (!this->p) {
-                this->p = Require(Greenlet_Intern(str));
+                this->p = Require(PyUnicode_InternFromString(str));
                 this->str = str;
             }
             else {
@@ -675,11 +673,7 @@ namespace greenlet {
             if (!py_str) {
                 return "(nil)";
             }
-#if PY_MAJOR_VERSION >= 3
             return PyUnicode_AsUTF8(py_str.borrow());
-#else
-            return PyString_AsString(py_str.borrow());
-#endif
         }
         return "(nil)";
     }

--- a/src/greenlet/greenlet_slp_switch.hpp
+++ b/src/greenlet/greenlet_slp_switch.hpp
@@ -39,29 +39,11 @@
 static greenlet::Greenlet* volatile switching_thread_state = nullptr;
 
 
-#ifdef GREENLET_NOINLINE_SUPPORTED
 extern "C" {
 static int GREENLET_NOINLINE(slp_save_state_trampoline)(char* stackref);
 static void GREENLET_NOINLINE(slp_restore_state_trampoline)();
 }
-#define GREENLET_NOINLINE_INIT() \
-    do {                         \
-    } while (0)
-#else
-/* force compiler to call functions via pointers */
-/* XXX: Do we even want/need to support such compilers? This code path
-   is untested on CI. */
-extern "C" {
-static int (slp_save_state_trampoline)(char* stackref);
-static void (slp_restore_state_trampoline)();
-}
-#define GREENLET_NOINLINE(name) cannot_inline_##name
-#define GREENLET_NOINLINE_INIT()                                  \
-    do {                                                              \
-            slp_save_state_trampoline = GREENLET_NOINLINE(slp_save_state_trampoline); \
-            slp_restore_state_trampoline = GREENLET_NOINLINE(slp_restore_state_trampoline); \
-    } while (0)
-#endif
+
 
 #define SLP_SAVE_STATE(stackref, stsizediff) \
 do {                                                    \

--- a/src/greenlet/greenlet_thread_state.hpp
+++ b/src/greenlet/greenlet_thread_state.hpp
@@ -532,30 +532,12 @@ public:
 
 };
 
-#if G_USE_STANDARD_THREADING == 1
+
 // We can't use the PythonAllocator for this, because we push to it
 // from the thread state destructor, which doesn't have the GIL,
 // and Python's allocators can only be called with the GIL.
 typedef std::vector<ThreadState*> cleanup_queue_t;
-#else
-class cleanup_queue_t {
-public:
-    inline ssize_t size() const { return 0; };
-    inline bool empty() const { return true; };
-    inline void pop_back()
-    {
-        throw std::out_of_range("empty queue.");
-    };
-    inline ThreadState* back()
-    {
-        throw std::out_of_range("empty queue.");
-    };
-    inline void push_back(ThreadState* g)
-    {
-        throw std::out_of_range("empty queue.");
-    };
-};
-#endif
+
 }; // namespace greenlet
 
 #endif

--- a/src/greenlet/greenlet_thread_support.hpp
+++ b/src/greenlet/greenlet_thread_support.hpp
@@ -3,42 +3,22 @@
 
 /**
  * Defines various utility functions to help greenlet integrate well
- * with threads. When possible, we use portable C++ 11 threading; when
- * not possible, we will use platform specific APIs if needed and
- * available. (Currently, this is only for Python 2.7 on Windows.)
+ * with threads. This used to be needed when we supported Python
+ * 2.7 on Windows, which used a very old compiler. We wrote an
+ * alternative implementation using Python APIs and POSIX or Windows
+ * APIs, but that's no longer needed. So this file is a shadow of its
+ * former self --- but may be needed in the future.
  */
 
 #include <stdexcept>
+#include <thread>
+#include <mutex>
+
 #include "greenlet_compiler_compat.hpp"
 
-// Allow setting this to 0 on the command line so that we
-// can test these code paths on compilers that otherwise support
-// standard threads.
-#ifndef G_USE_STANDARD_THREADING
-#if __cplusplus >= 201103
-// Cool. We should have standard support
-#    define G_USE_STANDARD_THREADING 1
-#elif defined(_MSC_VER)
-// MSVC doesn't use a modern version of __cplusplus automatically, you
-// have to opt-in to update it with /Zc:__cplusplus, but that's not
-// available on our old version of visual studio for Python 2.7
-#    if _MSC_VER <= 1500
-// Python 2.7 on Windows. Use the Python thread state and native Win32 APIs.
-#        define G_USE_STANDARD_THREADING 0
-#    else
-// Assume we have a compiler that supports it. The Appveyor compilers
-// we use all do have standard support
-#        define G_USE_STANDARD_THREADING 1
-#    endif
-#elif defined(__GNUC__) || defined(__clang__)
-// All tested versions either do, or can with the right --std argument, support what we need
-#    define G_USE_STANDARD_THREADING 1
-#else
-#    define G_USE_STANDARD_THREADING 0
-#endif
-#endif /* G_USE_STANDARD_THREADING */
-
 namespace greenlet {
+    typedef std::mutex Mutex;
+    typedef std::lock_guard<Mutex> LockGuard;
     class LockInitError : public std::runtime_error
     {
     public:
@@ -47,98 +27,5 @@ namespace greenlet {
     };
 };
 
-
-#if G_USE_STANDARD_THREADING == 1
-#    define G_THREAD_LOCAL_SUPPORTS_DESTRUCTOR 1
-#    include <thread>
-#    include <mutex>
-#    define G_THREAD_LOCAL_VAR thread_local
-namespace greenlet {
-    typedef std::mutex Mutex;
-    typedef std::lock_guard<Mutex> LockGuard;
-};
-#else
-// NOTE: At this writing, the mutex isn't currently required;
-// we don't use a shared cleanup queue or Py_AddPendingCall in this
-// model, we rely on the thread state dictionary for cleanup.
-#    if defined(_MSC_VER)
-//       We should only hit this case for Python 2.7 on Windows.
-#        define G_THREAD_LOCAL_VAR __declspec(thread)
-#        include <windows.h>
-namespace greenlet {
-    class Mutex
-    {
-        CRITICAL_SECTION _mutex;
-        G_NO_COPIES_OF_CLS(Mutex);
-    public:
-        Mutex()
-        {
-            InitializeCriticalSection(&this->_mutex);
-        };
-
-        void Lock()
-        {
-            EnterCriticalSection(&this->_mutex);
-        };
-
-        void UnLock()
-        {
-            LeaveCriticalSection(&this->_mutex);
-        };
-    };
-};
-#    elif (defined(__GNUC__) || defined(__clang__)) || (defined(__SUNPRO_C))
-// GCC, clang, SunStudio all use __thread for thread-local variables.
-// For locks, we can use PyThread APIs, officially added in 3.2, but
-// present back to 2.7
-#        define G_THREAD_LOCAL_VAR __thread
-#        include "pythread.h"
-namespace greenlet {
-    class Mutex
-    {
-        PyThread_type_lock _mutex;
-        G_NO_COPIES_OF_CLS(Mutex);
-    public:
-        Mutex()
-        {
-            this->_mutex = PyThread_allocate_lock();
-            if (!this->_mutex) {
-                throw LockInitError("Failed to initialize mutex.");
-            }
-        };
-
-        void Lock()
-        {
-            PyThread_acquire_lock(this->_mutex, WAIT_LOCK);
-        };
-
-        void UnLock()
-        {
-            PyThread_release_lock(this->_mutex);
-        };
-    };
-};
-#    else
-#        error Unable to declare thread-local variables.
-#    endif
-// the RAII lock keeper for all non-standard threading platforms.
-namespace greenlet {
-    class LockGuard
-    {
-        Mutex& _mutex;
-        G_NO_COPIES_OF_CLS(LockGuard);
-    public:
-        LockGuard(Mutex& m) : _mutex(m)
-        {
-            this->_mutex.Lock();
-        };
-        ~LockGuard()
-        {
-            this->_mutex.UnLock();
-        };
-    };
-
-};
-#endif /* G_USE_STANDARD_THREADING == 1 */
 
 #endif /* GREENLET_THREAD_SUPPORT_HPP */

--- a/src/greenlet/tests/_test_extension.c
+++ b/src/greenlet/tests/_test_extension.c
@@ -203,8 +203,8 @@ static PyMethodDef test_methods[] = {
     {NULL, NULL, 0, NULL}
 };
 
-#if PY_MAJOR_VERSION >= 3
-#    define INITERROR return NULL
+
+#define INITERROR return NULL
 
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        TEST_MODULE_NAME,
@@ -218,27 +218,14 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
 
 PyMODINIT_FUNC
 PyInit__test_extension(void)
-#else
-#    define INITERROR return
-PyMODINIT_FUNC
-init_test_extension(void)
-#endif
 {
     PyObject* module = NULL;
-
-#if PY_MAJOR_VERSION >= 3
     module = PyModule_Create(&moduledef);
-#else
-    module = Py_InitModule(TEST_MODULE_NAME, test_methods);
-#endif
 
     if (module == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     PyGreenlet_Import();
-
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }

--- a/src/greenlet/tests/_test_extension_cpp.cpp
+++ b/src/greenlet/tests/_test_extension_cpp.cpp
@@ -149,8 +149,6 @@ static PyMethodDef test_methods[] = {
      "Throws C++ exception. Calling this function directly should abort the process."},
     {NULL, NULL, 0, NULL}};
 
-#if PY_MAJOR_VERSION >= 3
-#    define INITERROR return NULL
 
 static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
                                        "greenlet.tests._test_extension_cpp",
@@ -164,33 +162,22 @@ static struct PyModuleDef moduledef = {PyModuleDef_HEAD_INIT,
 
 PyMODINIT_FUNC
 PyInit__test_extension_cpp(void)
-#else
-#    define INITERROR return
-PyMODINIT_FUNC
-init_test_extension_cpp(void)
-#endif
 {
     PyObject* module = NULL;
 
-#if PY_MAJOR_VERSION >= 3
     module = PyModule_Create(&moduledef);
-#else
-    module = Py_InitModule("greenlet.tests._test_extension_cpp", test_methods);
-#endif
 
     if (module == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     PyGreenlet_Import();
     if (_PyGreenlet_API == NULL) {
-        INITERROR;
+        return NULL;
     }
 
     p_test_exception_throw = test_exception_throw;
     p_test_exception_switch_recurse = test_exception_switch_recurse;
 
-#if PY_MAJOR_VERSION >= 3
     return module;
-#endif
 }

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -578,8 +578,6 @@ class TestGreenlet(TestCase):
         self.assertEqual(value, 42)
 
     def test_tuple_subclass(self):
-        # XXX: This is failing on Python 2 with a SystemError: error return without exception set
-
         # The point of this test is to see what happens when a custom
         # tuple subclass is used as an object passed directly to the C
         # function ``green_switch``; part of ``green_switch`` checks
@@ -591,13 +589,10 @@ class TestGreenlet(TestCase):
         # `apply` function directly passes the given args tuple object
         # to the underlying function, whereas the Python 3 version
         # unpacks and repacks into an actual tuple. This could still
-        # happen using the C API on Python 3 though.
-        if sys.version_info[0] > 2:
-            # There's no apply in Python 3.x
-            def _apply(func, a, k):
-                func(*a, **k)
-        else:
-            _apply = apply # pylint:disable=undefined-variable
+        # happen using the C API on Python 3 though. We should write a
+        # builtin version of apply() ourself.
+        def _apply(func, a, k):
+            func(*a, **k)
 
         class mytuple(tuple):
             def __len__(self):

--- a/src/greenlet/tests/test_greenlet_trash.py
+++ b/src/greenlet/tests/test_greenlet_trash.py
@@ -27,17 +27,10 @@ implementation (like most of the rest of this package):
 """
 from __future__ import print_function, absolute_import, division
 
-import sys
 import unittest
-
-
 
 class TestTrashCanReEnter(unittest.TestCase):
 
-    @unittest.skipUnless(
-        sys.version_info[0] > 2,
-        "Python 2 tracks this slightly differently, so our test doesn't catch a problem there. "
-    )
     def test_it(self):
         # Try several times to trigger it, because it isn't 100%
         # reliable.

--- a/src/greenlet/tests/test_leaks.py
+++ b/src/greenlet/tests/test_leaks.py
@@ -17,7 +17,6 @@ import greenlet
 from . import TestCase
 from .leakcheck import fails_leakcheck
 from .leakcheck import ignores_leakcheck
-from .leakcheck import RUNNING_ON_GITHUB_ACTIONS
 from .leakcheck import RUNNING_ON_MANYLINUX
 
 try:
@@ -309,11 +308,11 @@ class TestLeaks(TestCase):
         # and this set of tests is relatively fragile, depending on
         # OS and memory management details. So we want to run it on 3.11+
         # (obviously) but not every older 3.x version in order to reduce
-        # false negatives.
-        if sys.version_info[0] >= 3 and sys.version_info[:2] < (3, 8):
+        # false negatives. At the moment, those false results seem to have
+        # resolved, so we are actually running this on 3.8+
+        assert sys.version_info[0] >= 3
+        if sys.version_info[:2] < (3, 8):
             self.skipTest('Only observed on 3.11')
-        if sys.version_info[0] == 2 and RUNNING_ON_GITHUB_ACTIONS:
-            self.skipTest('Hard to get a stable pattern here')
         if RUNNING_ON_MANYLINUX:
             self.skipTest("Slow and not worth repeating here")
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,6 @@
 envlist =
     py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
 
-# XXX: Is non-standard thread mode still needed? Check on that.
 [testenv]
 commands =
     python -c 'import greenlet._greenlet as G; assert G.GREENLET_USE_STANDARD_THREADING'

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,10 @@ envlist =
 
 # XXX: Is non-standard thread mode still needed? Check on that.
 [testenv]
-setenv =
-    ns: CPPFLAGS=-DG_USE_STANDARD_THREADING=0
 commands =
-    ns: python -c 'import greenlet._greenlet as G; assert not G.GREENLET_USE_STANDARD_THREADING'
-    !ns: python -c 'import greenlet._greenlet as G; assert G.GREENLET_USE_STANDARD_THREADING'
+    python -c 'import greenlet._greenlet as G; assert G.GREENLET_USE_STANDARD_THREADING'
     python -m unittest discover -v greenlet.tests
-    !ns: sphinx-build -b doctest -d docs/_build/doctrees-{envname} docs docs/_build/doctest-{envname}
+    sphinx-build -b doctest -d docs/_build/doctrees-{envname} docs docs/_build/doctest-{envname}
 sitepackages = False
 extras =
     test

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    py35,py36,py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
+    py36,py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
 
+# XXX: Is non-standard thread mode still needed? Check on that.
 [testenv]
 setenv =
     ns: CPPFLAGS=-DG_USE_STANDARD_THREADING=0

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py36,py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
+    py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
 
 # XXX: Is non-standard thread mode still needed? Check on that.
 [testenv]


### PR DESCRIPTION
3.7 is the oldest version not past its end of life, so that's where I'm cutting things. Because this is both API and ABI binary compatible with greenlet 2.x, it won't force downstream projects to drop support unless they want to.

This removes a fair amount of legacy code; especially the removal of the `#if/#else` blocks contributes substantially to readability.