### PR TITLE
Fix ABI tag in macOS wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,10 +56,6 @@ jobs:
       run: |
         python setup.py bdist_wheel
         python -m pip install -U -e ".[test,docs]"
-        # Something in the build system isn't detecting that we're building for both,
-        # so we're getting tagged with just x86_64. Force the universal2 tag.
-        # (I've verified that the .so files are in fact universal, with both architectures.)
-        wheel tags --remove --abi-tag universal2 dist/*whl
       env:
         # Unlike the above, we are actually distributing these
         # wheels, so they need to be built for production use.


### PR DESCRIPTION
ABI tags look OK now:

```
Checking dist/greenlet-3.0.1.dev0-cp312-cp312-macosx_10_9_universal2.whl: PASSED
```

Closes #369 