### PR TITLE
Restore stack introspection ability on 3.12

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,11 +2,20 @@
  Changes
 =========
 
-3.0.3 (unreleased)
+3.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
-
+- Python 3.12: Restore the full ability to walk the stack of a suspended
+  greenlet; previously only the innermost frame was exposed.
+  For performance reasons, there are still some restrictions relative to
+  older Python versions; in particular, by default it is only valid to walk
+  a suspended greenlet's stack in between a ``gr_frame`` access and the next
+  resumption of the greenlet. A more flexible mode can be enabled by setting
+  the greenlet's new ``gr_frames_always_exposed`` attribute to True. If you
+  get a Python interpreter crash on 3.12+ when accessing the ``f_back`` of a
+  suspended greenlet frame, you're probably accessing it in a way that
+  requires you to set this attribute. See `issue 388
+  <https://github.com/python-greenlet/greenlet/issues/388>`_.
 
 3.0.2 (2023-12-08)
 ==================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,7 +32,6 @@ Greenlets
 
    .. autoattribute:: gr_context
 
-
       The :class:`contextvars.Context` in which ``g`` will run.
       Writable; defaults to ``None``, reflecting that a greenlet
       starts execution in an empty context unless told otherwise.
@@ -55,6 +54,30 @@ Greenlets
       object's ``f_back`` attributes. ``gr_frame`` is non-None only
       for suspended greenlets; it is None if the greenlet is dead, not
       yet started, or currently executing.
+
+      .. warning:: Greenlet stack introspection is fragile on CPython 3.12
+         and later. The frame objects of a suspended greenlet are not safe
+         to access as-is, but must be adjusted by the greenlet package in
+         order to make traversing ``f_back`` links not crash the interpreter,
+         and restored to their original state when resuming the greenlet.
+         This is all handled transparently as long as you obtain references
+         to greenlet frames only via the ``gr_frame`` attribute and you finish
+         accessing them before the greenlet next resumes. If you obtain
+         frames in other ways, or hold onto them across their greenlet's
+         resumption, you must set the ``gr_frames_always_exposed`` attribute
+         in order to make that safe.
+
+   .. autoattribute:: gr_frames_always_exposed
+
+      Writable boolean indicating whether this greenlet will take extra action,
+      each time it is suspended, to ensure that its frame objects are always
+      safe to access. Normally such action is only taken when an access
+      to the ``gr_frame`` attribute occurs, which means you can only safely
+      walk a greenlet's stack in between accessing ``gr_frame`` and resuming
+      the greenlet. This is relevant only on CPython 3.12 and later; earlier
+      versions still permit writing the attribute, but because their frame
+      objects are safe to access regardless, such writes have no effect and
+      the attribute always reads as true.
 
    .. autoattribute:: parent
 

--- a/src/greenlet/TGreenlet.cpp
+++ b/src/greenlet/TGreenlet.cpp
@@ -168,6 +168,11 @@ Greenlet::g_switchstack(void)
         current->exception_state << tstate;
         this->python_state.will_switch_from(tstate);
         switching_thread_state = this;
+#if GREENLET_PY312
+        if (current->python_state.expose_frames_on_every_suspension) {
+            current->expose_frames();
+        }
+#endif
     }
     assert(this->args() || PyErr_Occurred());
     // If this is the first switch into a greenlet, this will
@@ -606,5 +611,103 @@ bool Greenlet::is_currently_running_in_some_thread() const
     return this->stack_state.active() && !this->python_state.top_frame();
 }
 
+#if GREENLET_PY312
+void GREENLET_NOINLINE(Greenlet::expose_frames)()
+{
+    if (!this->python_state.frame_exposure_needs_stack_rewrite()) {
+        return; // nothing to do
+    }
+
+    _PyInterpreterFrame* last_complete_iframe = nullptr;
+    _PyInterpreterFrame* iframe = this->python_state.top_frame()->f_frame;
+    while (iframe) {
+        // We must make a copy before looking at the iframe contents,
+        // since iframe might point to a portion of the greenlet's C stack
+        // that was spilled when switching greenlets.
+        _PyInterpreterFrame iframe_copy;
+        this->stack_state.copy_from_stack(&iframe_copy, iframe, sizeof(*iframe));
+        if (!_PyFrame_IsIncomplete(&iframe_copy)) {
+            // If the iframe were OWNED_BY_CSTACK then it would always be
+            // incomplete. Since it's not incomplete, it's not on the C stack
+            // and we can access it through the original `iframe` pointer
+            // directly.  This is important since GetFrameObject might
+            // lazily _create_ the frame object and we don't want the
+            // interpreter to lose track of it.
+            assert(iframe_copy.owner != FRAME_OWNED_BY_CSTACK);
+
+            // We really want to just write:
+            //     PyFrameObject* frame = _PyFrame_GetFrameObject(iframe);
+            // but _PyFrame_GetFrameObject calls _PyFrame_MakeAndSetFrameObject
+            // which is not a visible symbol in libpython. The easiest
+            // way to get a public function to call it is using
+            // PyFrame_GetBack, which is defined as follows:
+            //     assert(frame != NULL);
+            //     assert(!_PyFrame_IsIncomplete(frame->f_frame));
+            //     PyFrameObject *back = frame->f_back;
+            //     if (back == NULL) {
+            //         _PyInterpreterFrame *prev = frame->f_frame->previous;
+            //         prev = _PyFrame_GetFirstComplete(prev);
+            //         if (prev) {
+            //             back = _PyFrame_GetFrameObject(prev);
+            //         }
+            //     }
+            //     return (PyFrameObject*)Py_XNewRef(back);
+            if (!iframe->frame_obj) {
+                PyFrameObject dummy_frame;
+                _PyInterpreterFrame dummy_iframe;
+                dummy_frame.f_back = nullptr;
+                dummy_frame.f_frame = &dummy_iframe;
+                // force the iframe to be considered complete without
+                // needing to check its code object:
+                dummy_iframe.owner = FRAME_OWNED_BY_GENERATOR;
+                dummy_iframe.previous = iframe;
+                assert(!_PyFrame_IsIncomplete(&dummy_iframe));
+                // Drop the returned reference immediately; the iframe
+                // continues to hold a strong reference
+                Py_XDECREF(PyFrame_GetBack(&dummy_frame));
+                assert(iframe->frame_obj);
+            }
+
+            // This is a complete frame, so make the last one of those we saw
+            // point at it, bypassing any incomplete frames (which may have
+            // been on the C stack) in between the two. We're overwriting
+            // last_complete_iframe->previous and need that to be reversible,
+            // so we store the original previous ptr in the frame object
+            // (which we must have created on a previous iteration through
+            // this loop). The frame object has a bunch of storage that is
+            // only used when its iframe is OWNED_BY_FRAME_OBJECT, which only
+            // occurs when the frame object outlives the frame's execution,
+            // which can't have happened yet because the frame is currently
+            // executing as far as the interpreter is concerned. So, we can
+            // reuse it for our own purposes.
+            assert(iframe->owner == FRAME_OWNED_BY_THREAD ||
+                   iframe->owner == FRAME_OWNED_BY_GENERATOR);
+            if (last_complete_iframe) {
+                assert(last_complete_iframe->frame_obj);
+                memcpy(&last_complete_iframe->frame_obj->_f_frame_data[0],
+                       &last_complete_iframe->previous, sizeof(void *));
+                last_complete_iframe->previous = iframe;
+            }
+            last_complete_iframe = iframe;
+        }
+        // Frames that are OWNED_BY_FRAME_OBJECT are linked via the
+        // frame's f_back while all others are linked via the iframe's
+        // previous ptr. Since all the frames we traverse are running
+        // as far as the interpreter is concerned, we don't have to
+        // worry about the OWNED_BY_FRAME_OBJECT case.
+        iframe = iframe_copy.previous;
+    }
+
+    // Give the outermost complete iframe a null previous pointer to
+    // account for any potential incomplete/C-stack iframes between it
+    // and the actual top-of-stack
+    if (last_complete_iframe) {
+        assert(last_complete_iframe->frame_obj);
+        memcpy(&last_complete_iframe->frame_obj->_f_frame_data[0],
+               &last_complete_iframe->previous, sizeof(void *));
+        last_complete_iframe->previous = nullptr;
+    }
+}
+#endif
 
 }; // namespace greenlet

--- a/src/greenlet/TStackState.cpp
+++ b/src/greenlet/TStackState.cpp
@@ -226,6 +226,37 @@ StackState::~StackState()
     }
 }
 
+void StackState::copy_from_stack(void* vdest, const void* vsrc, size_t n) const
+{
+    char* dest = static_cast<char*>(vdest);
+    const char* src = static_cast<const char*>(vsrc);
+    if (src + n <= _stack_start || src >= _stack_start + _stack_saved ||
+        _stack_saved == 0) {
+        // Nothing we're copying was spilled from the stack
+        memcpy(dest, src, n);
+        return;
+    }
+    if (src < _stack_start) {
+        // Copy the part before the saved stack.
+        // We know src + n > _stack_start due to the test above.
+        size_t nbefore = _stack_start - src;
+        memcpy(dest, src, nbefore);
+        dest += nbefore;
+        src += nbefore;
+        n -= nbefore;
+    }
+    // We know src >= _stack_start after the before-copy, and
+    // src < _stack_start + _stack_saved due to the first if condition
+    size_t nspilled = std::min<size_t>(n, _stack_start + _stack_saved - src);
+    memcpy(dest, stack_copy + (src - _stack_start), nspilled);
+    dest += nspilled;
+    src += nspilled;
+    n -= nspilled;
+    if (n > 0) {
+        // Copy the part after the saved stack
+        memcpy(dest, src, n);
+    }
+}
 
 }; // namespace greenlet
 

--- a/src/greenlet/__init__.py
+++ b/src/greenlet/__init__.py
@@ -25,7 +25,7 @@ __all__ = [
 ###
 # Metadata
 ###
-__version__ = '3.0.3.dev0'
+__version__ = '3.1.0.dev0'
 from ._greenlet import _C_API # pylint:disable=no-name-in-module
 
 ###

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -758,8 +758,37 @@ green_setcontext(BorrowedGreenlet self, PyObject* nctx, void* UNUSED(context))
 static PyObject*
 green_getframe(BorrowedGreenlet self, void* UNUSED(context))
 {
+#if GREENLET_PY312
+    self->expose_frames();
+#endif
     const PythonState::OwnedFrame& top_frame = self->top_frame();
     return top_frame.acquire_or_None();
+}
+
+static PyObject*
+green_getframeexposed(BorrowedGreenlet self, void* UNUSED(context))
+{
+#if GREENLET_PY312
+    if (!self->expose_frames_on_every_suspension()) {
+        Py_RETURN_FALSE;
+    }
+#endif
+    Py_RETURN_TRUE;
+}
+
+static int
+green_setframeexposed(BorrowedGreenlet self, PyObject* val, void* UNUSED(context))
+{
+    if (val != Py_True && val != Py_False) {
+        PyErr_Format(PyExc_TypeError,
+                     "expected a bool, not '%s'",
+                     Py_TYPE(val)->tp_name);
+        return -1;
+    }
+#if GREENLET_PY312
+    self->set_expose_frames_on_every_suspension(val == Py_True);
+#endif
+    return 0;
 }
 
 static PyObject*
@@ -979,6 +1008,10 @@ static PyGetSetDef green_getsets[] = {
     {"run", (getter)green_getrun, (setter)green_setrun, /*XXX*/ NULL},
     {"parent", (getter)green_getparent, (setter)green_setparent, /*XXX*/ NULL},
     {"gr_frame", (getter)green_getframe, NULL, /*XXX*/ NULL},
+    {"gr_frames_always_exposed",
+     (getter)green_getframeexposed,
+     (setter)green_setframeexposed,
+     /*XXX*/ NULL},
     {"gr_context",
      (getter)green_getcontext,
      (setter)green_setcontext,

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -118,10 +118,26 @@ namespace greenlet
         PyObject** datastack_limit;
 #endif
 #if GREENLET_PY312
-        _PyInterpreterFrame* _prev_frame;
+        // The PyInterpreterFrame list on 3.12+ contains some entries that are
+        // on the C stack, which can't be directly accessed while a greenlet is
+        // suspended. In order to keep greenlet gr_frame introspection working,
+        // we hook the gr_frame accessor to rewrite the interpreter frame list
+        // to skip these C-stack frames; we call this "exposing" the greenlet's
+        // frames because it makes them valid to work with in Python. Then when
+        // the greenlet is resumed we need to remember to reverse the operation
+        // we did. The C-stack frames are "entry frames" which are a low-level
+        // interpreter detail; they're not needed for introspection, but do
+        // need to be present for the eval loop to work.
+        bool frames_were_exposed;
+        void unexpose_frames();
 #endif
 
     public:
+#if GREENLET_PY312
+        // State used by Greenlet class, stored here to improve packing
+        bool expose_frames_on_every_suspension;
+#endif
+
         PythonState();
         // You can use this for testing whether we have a frame
         // or not. It returns const so they can't modify it.
@@ -137,9 +153,24 @@ namespace greenlet
 #if GREENLET_USE_CFRAME
         void set_new_cframe(_PyCFrame& frame) noexcept;
 #endif
+
         inline void may_switch_away() noexcept;
         inline void will_switch_from(PyThreadState *const origin_tstate) noexcept;
         void did_finish(PyThreadState* tstate) noexcept;
+
+#if GREENLET_PY312
+        // Called when we're about to make the stack of a suspended greenlet
+        // visible to Python code. If it returns true, the stack must be fixed
+        // up first using the logic in Greenlet::expose_frames().
+        bool frame_exposure_needs_stack_rewrite() noexcept
+        {
+            if (!top_frame() || frames_were_exposed) {
+                return false;
+            }
+            frames_were_exposed = true;
+            return true;
+        }
+#endif
     };
 
     class StackState
@@ -186,6 +217,14 @@ namespace greenlet
 #ifdef GREENLET_USE_STDIO
         friend std::ostream& operator<<(std::ostream& os, const StackState& s);
 #endif
+
+        // Fill in [dest, dest + n) with the values that would be at
+        // [src, src + n) while this greenlet is running. This is like memcpy
+        // except that if the greenlet is suspended it accounts for the portion
+        // of the greenlet's stack that was spilled to the heap. `src` may
+        // be on this greenlet's stack, or on the heap, but not on a different
+        // greenlet's stack.
+        void copy_from_stack(void* dest, const void* src, size_t n) const;
     };
 #ifdef GREENLET_USE_STDIO
     std::ostream& operator<<(std::ostream& os, const StackState& s);
@@ -376,6 +415,38 @@ namespace greenlet
         // The thread state will be null if the thread the greenlet
         // was running in was known to have exited.
         void deallocing_greenlet_in_thread(const ThreadState* current_state);
+
+#if GREENLET_PY312
+        // Must be called on 3.12+ before exposing a suspended greenlet's
+        // frames to user code. This synthesizes a frame object if necessary
+        // for each interpreter frame on the greenlet's stack, and stitches
+        // together their f_back pointers so that Python accesses to f_back
+        // don't need to walk the interpreter frame stack. This is important
+        // because the interpreter frame stack contains some entries that are
+        // on the C stack and the interpreter will crash when trying to
+        // traverse those for a suspended greenlet. The f_back pointer work
+        // must be undone before resuming the greenlet because the interpreter
+        // assumes f_back is nullptr for running frames. This is tracked via
+        // PythonState::frames_were_exposed.
+        void expose_frames();
+
+        // To support code that exposes greenlet frames other than through
+        // gr_frame, it is possible to tell a greenlet to expose its frames
+        // every time it suspends itself. This will harm performance and
+        // should only be used if necessary. Attached to the Python attribute
+        // 'gr_frames_always_exposed'.
+        inline bool expose_frames_on_every_suspension() const noexcept
+        {
+            return this->python_state.expose_frames_on_every_suspension;
+        }
+        inline void set_expose_frames_on_every_suspension(bool value) noexcept
+        {
+            this->python_state.expose_frames_on_every_suspension = value;
+            if (value) {
+                expose_frames();
+            }
+        }
+#endif
 
         // TODO: Figure out how to make these non-public.
         inline void slp_restore_state() noexcept;

--- a/src/greenlet/tests/_test_extension_cpp.cpp
+++ b/src/greenlet/tests/_test_extension_cpp.cpp
@@ -100,6 +100,15 @@ py_test_exception_throw_std(PyObject* self, PyObject* args)
     return NULL;
 }
 
+static PyObject*
+py_test_call(PyObject* self, PyObject* arg)
+{
+    PyObject* noargs = PyTuple_New(0);
+    PyObject* ret = PyObject_Call(arg, noargs, nullptr);
+    Py_DECREF(noargs);
+    return ret;
+}
+
 
 
 /* test_exception_switch_and_do_in_g2(g2func)
@@ -172,6 +181,12 @@ static PyMethodDef test_methods[] = {
      (PyCFunction)&py_test_exception_throw_std,
      METH_VARARGS,
      "Throws standard C++ exception. Calling this function directly should abort the process."
+    },
+    {"test_call",
+     (PyCFunction)&py_test_call,
+     METH_O,
+     "Call the given callable. Unlike calling it directly, this creates a "
+     "new C-level stack frame, which may be helpful in testing."
     },
     {NULL, NULL, 0, NULL}
 };


### PR DESCRIPTION
Fixes #388. The `gr_frame` accessor now returns a frame whose `f_back` chain is valid to walk, by rewriting the frame list on demand to exclude C-stack frames and reversing this the next time the greenlet is resumed. This carries an assumption that stack walking of a suspended greenlet occurs between an access to `gr_frame` and the next resumption of the greenlet, which should be valid for most applications. For those that are doing something stranger, I added a new `gr_frames_always_exposed` attribute; if set to True it will cause the rewrite to occur every time the greenlet is suspended, providing full semantic parity with 3.11-and-earlier at some performance cost.

I did some perf testing on my laptop using 
```
% python -m timeit -s 'import greenlet
def switcher(main):
  while True:
    main.switch()
gr = greenlet.greenlet(switcher)
gr.switch(greenlet.getcurrent())' 'gr.switch()'
```
It was pretty consistently 286-287 nsec before this change and 281 nsec after. (This makes sense; it's less expensive to check the `frames_were_exposed` bool than it is to reset-and-set the topmost frame's `previous` pointer, which is what we were doing previously.)

If I set the new `gr_frames_always_exposed` attribute to True, we're back up to 288 nsec per loop (though the penalty of this would increase with the stack depth of the greenlet, and re-exposing existing frames is much less expensive than exposing new frames because the former case doesn't need to allocate any new frame objects). If I access `gr_frame` on every switch, it's 302 nsec per loop. All of this seems acceptable to me. I don't know if you have any more realistic performance tests available; it would be good to run them if so.

I marked this as 3.1.0 since it provides a new public API. Feel free to adjust based on however you think about versioning.