### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python: 3.12
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/make-manylinux
+++ b/make-manylinux
@@ -26,6 +26,7 @@ if [ -d /greenlet -a -d /opt/python ]; then
     # Build in an isolated directory
     mkdir /tmp/build
     cd /tmp/build
+    git config --global --add safe.directory /greenlet/.git
     git clone /greenlet greenlet
     cd greenlet
 


### PR DESCRIPTION
* Don't test old Python on macos-latest. GitHub Action macos-latest was updated to arm64 which only supports recent Python versions. Continue testing old Python versions on Ubuntu.
* Fix make-manylinux: set /greenlet as safe directory.