### PR TITLE
Check if interpreter is finalizing in ~ThreadStateCreator

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
+        python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
         os: [ubuntu-latest, macos-latest]
     steps:
     - uses: actions/checkout@v3
@@ -35,6 +35,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: setup.py
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install -U pip setuptools wheel

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         sphinx-build -b doctest -d docs/_build/doctrees2 docs docs/_build/doctest2
     - name: Lint
-      if: matrix.python-version == '3.10' && startsWith(runner.os, 'Linux')
+      if: matrix.python-version == '3.12' && startsWith(runner.os, 'Linux')
       # We only need to do this on one version.
       # We do this here rather than a separate job to avoid the compilation overhead.
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,9 @@ jobs:
         os: [ubuntu-latest]
         include:
           - os: macos-latest
-            python: 3.12
+            python-version: 3.12
+          - os: macos-latest
+            python-version: 3.13
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,10 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12", "3.13"]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
+        include:
+          - os: macos-latest
+            python: 3.12
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,19 @@
  Changes
 =========
 
-3.0.4 (unreleased)
+3.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Adds support for Python 3.13.
+
+.. note::
+
+   greenlet will not work in no-gil (free threaded) builds of CPython.
+   Internally, greenlet heavily depends on the GIL.
+
+.. note::
+
+    This will be the last release to support Python 3.7 and 3.8.
 
 
 3.0.3 (2023-12-21)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,6 +42,12 @@ environment:
 
     # Fully supported 64-bit versions, with testing. This should be
     # all the current (non EOL) versions.
+    - PYTHON: "C:\\Python313-x64"
+      PYTHON_VERSION: "3.13.0"
+      PYTHON_ARCH: "64"
+      PYTHON_EXE: python
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+
     - PYTHON: "C:\\Python312-x64"
       PYTHON_VERSION: "3.12.0"
       PYTHON_ARCH: "64"

--- a/make-manylinux
+++ b/make-manylinux
@@ -33,6 +33,8 @@ if [ -d /greenlet -a -d /opt/python ]; then
     mkdir -p /greenlet/wheelhouse
     OPATH="$PATH"
     which auditwheel
+    echo "Installed Python versions"
+    ls -l /opt/python
     for variant in `ls -d /opt/python/cp{313,37,38,39,310,311,312}*`; do
         export PATH="$variant/bin:$OPATH"
         echo "Building $variant $(python --version)"

--- a/make-manylinux
+++ b/make-manylinux
@@ -36,6 +36,10 @@ if [ -d /greenlet -a -d /opt/python ]; then
     echo "Installed Python versions"
     ls -l /opt/python
     for variant in `ls -d /opt/python/cp{313,37,38,39,310,311,312}*`; do
+        if [ "$variant" = "/opt/python/cp313-313t" ]; then
+            echo "Skipping no-gil build. The GIL is required."
+            continue
+        fi
         export PATH="$variant/bin:$OPATH"
         echo "Building $variant $(python --version)"
 

--- a/make-manylinux
+++ b/make-manylinux
@@ -26,6 +26,7 @@ if [ -d /greenlet -a -d /opt/python ]; then
     # Build in an isolated directory
     mkdir /tmp/build
     cd /tmp/build
+    git config --global --add safe.directory /greenlet/.git
     git clone /greenlet greenlet
     cd greenlet
 

--- a/make-manylinux
+++ b/make-manylinux
@@ -33,7 +33,7 @@ if [ -d /greenlet -a -d /opt/python ]; then
     mkdir -p /greenlet/wheelhouse
     OPATH="$PATH"
     which auditwheel
-    for variant in `ls -d /opt/python/cp{37,38,39,310,311,312}*`; do
+    for variant in `ls -d /opt/python/cp{313,37,38,39,310,311,312}*`; do
         export PATH="$variant/bin:$OPATH"
         echo "Building $variant $(python --version)"
 

--- a/src/greenlet/TPythonState.cpp
+++ b/src/greenlet/TPythonState.cpp
@@ -138,7 +138,9 @@ void PythonState::operator<<(const PyThreadState *const tstate) noexcept
   #else // not 312
     this->recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
   #endif // GREENLET_PY312
-  #if GREENLET_USE_CFRAME
+  #if GREENLET_PY313
+    this->current_frame = tstate->current_frame;
+  #elif GREENLET_USE_CFRAME
     this->current_frame = tstate->cframe->current_frame;
   #endif
     this->datastack_chunk = tstate->datastack_chunk;
@@ -212,7 +214,9 @@ void PythonState::operator>>(PyThreadState *const tstate) noexcept
   #else // \/ 3.11
     tstate->recursion_remaining = tstate->recursion_limit - this->recursion_depth;
   #endif // GREENLET_PY312
-  #if GREENLET_USE_CFRAME
+  #if GREENLET_PY313
+    tstate->current_frame = this->current_frame;
+  #elif GREENLET_USE_CFRAME
     tstate->cframe->current_frame = this->current_frame;
   #endif
     tstate->datastack_chunk = this->datastack_chunk;

--- a/src/greenlet/TPythonState.cpp
+++ b/src/greenlet/TPythonState.cpp
@@ -130,11 +130,13 @@ void PythonState::operator<<(const PyThreadState *const tstate) noexcept
 #if GREENLET_PY311
   #if GREENLET_PY312
     this->py_recursion_depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;
-    this->c_recursion_depth = C_RECURSION_LIMIT - tstate->c_recursion_remaining;
+    this->c_recursion_depth = Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining;
   #else // not 312
     this->recursion_depth = tstate->recursion_limit - tstate->recursion_remaining;
   #endif // GREENLET_PY312
+  #if GREENLET_USE_CFRAME
     this->current_frame = tstate->cframe->current_frame;
+  #endif
     this->datastack_chunk = tstate->datastack_chunk;
     this->datastack_top = tstate->datastack_top;
     this->datastack_limit = tstate->datastack_limit;
@@ -199,12 +201,14 @@ void PythonState::operator>>(PyThreadState *const tstate) noexcept
 #if GREENLET_PY311
   #if GREENLET_PY312
     tstate->py_recursion_remaining = tstate->py_recursion_limit - this->py_recursion_depth;
-    tstate->c_recursion_remaining = C_RECURSION_LIMIT - this->c_recursion_depth;
+    tstate->c_recursion_remaining = Py_C_RECURSION_LIMIT - this->c_recursion_depth;
     this->unexpose_frames();
   #else // \/ 3.11
     tstate->recursion_remaining = tstate->recursion_limit - this->recursion_depth;
   #endif // GREENLET_PY312
+  #if GREENLET_USE_CFRAME
     tstate->cframe->current_frame = this->current_frame;
+  #endif
     tstate->datastack_chunk = this->datastack_chunk;
     tstate->datastack_top = this->datastack_top;
     tstate->datastack_limit = this->datastack_limit;
@@ -238,7 +242,7 @@ void PythonState::set_initial_state(const PyThreadState* const tstate) noexcept
 #if GREENLET_PY312
     this->py_recursion_depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;
     // XXX: TODO: Comment from a reviewer:
-    //     Should this be ``C_RECURSION_LIMIT - tstate->c_recursion_remaining``?
+    //     Should this be ``Py_C_RECURSION_LIMIT - tstate->c_recursion_remaining``?
     // But to me it looks more like that might not be the right
     // initialization either?
     this->c_recursion_depth = tstate->py_recursion_limit - tstate->py_recursion_remaining;

--- a/src/greenlet/TThreadStateDestroy.cpp
+++ b/src/greenlet/TThreadStateDestroy.cpp
@@ -104,6 +104,9 @@ struct ThreadState_DestroyNoGIL
         // just always implement our own AddPendingCall, but I'd like to see if
         // this works first
         if (_Py_IsFinalizing()) {
+            fprintf(stderr,
+                    "greenlet: WARNING: Interpreter is finilizing. Ignoring"
+                    "call to Py_AddPendingCall; \n");
             return 0;
         }
         return Py_AddPendingCall(func, arg);

--- a/src/greenlet/TThreadStateDestroy.cpp
+++ b/src/greenlet/TThreadStateDestroy.cpp
@@ -105,7 +105,7 @@ struct ThreadState_DestroyNoGIL
         // this works first
         if (_Py_IsFinalizing()) {
             fprintf(stderr,
-                    "greenlet: WARNING: Interpreter is finilizing. Ignoring"
+                    "greenlet: WARNING: Interpreter is finalizing. Ignoring "
                     "call to Py_AddPendingCall; \n");
             return 0;
         }

--- a/src/greenlet/TThreadStateDestroy.cpp
+++ b/src/greenlet/TThreadStateDestroy.cpp
@@ -96,6 +96,16 @@ struct ThreadState_DestroyNoGIL
     // Python < 3.8 or >= 3.9
     static int AddPendingCall(int (*func)(void*), void* arg)
     {
+        // If the interpreter is in the middle of finalizing, we can't add a
+        // pending call. Trying to do so will end up in a SIGSEGV, as
+        // Py_AddPendingCall will not be able to get the interpreter and will
+        // try to dereference a NULL pointer. It's possible this can still
+        // segfault if we happen to get context switched, and maybe we should
+        // just always implement our own AddPendingCall, but I'd like to see if
+        // this works first
+        if (_Py_IsFinalizing()) {
+            return 0;
+        }
         return Py_AddPendingCall(func, arg);
     }
 #endif

--- a/src/greenlet/TThreadStateDestroy.cpp
+++ b/src/greenlet/TThreadStateDestroy.cpp
@@ -103,7 +103,11 @@ struct ThreadState_DestroyNoGIL
         // segfault if we happen to get context switched, and maybe we should
         // just always implement our own AddPendingCall, but I'd like to see if
         // this works first
+#if GREENLET_PY313
+        if (Py_IsFinalizing()) {
+#else
         if (_Py_IsFinalizing()) {
+#endif
             fprintf(stderr,
                     "greenlet: WARNING: Interpreter is finalizing. Ignoring "
                     "call to Py_AddPendingCall; \n");

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -1328,6 +1328,7 @@ mod_enable_optional_cleanup(PyObject* UNUSED(module), PyObject* flag)
     Py_RETURN_NONE;
 }
 
+#if !GREENLET_PY313
 PyDoc_STRVAR(mod_get_tstate_trash_delete_nesting_doc,
              "get_tstate_trash_delete_nesting() -> Integer\n"
              "\n"
@@ -1343,6 +1344,7 @@ mod_get_tstate_trash_delete_nesting(PyObject* UNUSED(module))
     return PyLong_FromLong(tstate->trash_delete_nesting);
 #endif
 }
+#endif
 
 static PyMethodDef GreenMethods[] = {
     {"getcurrent",
@@ -1356,7 +1358,9 @@ static PyMethodDef GreenMethods[] = {
     {"get_total_main_greenlets", (PyCFunction)mod_get_total_main_greenlets, METH_NOARGS, mod_get_total_main_greenlets_doc},
     {"get_clocks_used_doing_optional_cleanup", (PyCFunction)mod_get_clocks_used_doing_optional_cleanup, METH_NOARGS, mod_get_clocks_used_doing_optional_cleanup_doc},
     {"enable_optional_cleanup", (PyCFunction)mod_enable_optional_cleanup, METH_O, mod_enable_optional_cleanup_doc},
+#if !GREENLET_PY313
     {"get_tstate_trash_delete_nesting", (PyCFunction)mod_get_tstate_trash_delete_nesting, METH_NOARGS, mod_get_tstate_trash_delete_nesting_doc},
+#endif
     {NULL, NULL} /* Sentinel */
 };
 

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -55,6 +55,12 @@ https://bugs.python.org/issue46090). Summary of breaking internal changes:
 #    define GREENLET_PY312 0
 #endif
 
+#if PY_VERSION_HEX >= 0x30D0000
+#    define GREENLET_PY313 1
+#else
+#    define GREENLET_PY313 0
+#endif
+
 #ifndef Py_SET_REFCNT
 /* Py_REFCNT and Py_SIZE macros are converted to functions
 https://bugs.python.org/issue39573 */

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -12,17 +12,22 @@
 
 #if PY_VERSION_HEX >= 0x30A00B1
 #    define GREENLET_PY310 1
+#else
+#    define GREENLET_PY310 0
+#endif
+
 /*
 Python 3.10 beta 1 changed tstate->use_tracing to a nested cframe member.
 See https://github.com/python/cpython/pull/25276
 We have to save and restore this as well.
+
+Python 3.13 removed PyThreadState.cframe (GH-108035).
 */
+#if GREENLET_PY310 && PY_VERSION_HEX < 0x30D0000
 #    define GREENLET_USE_CFRAME 1
 #else
 #    define GREENLET_USE_CFRAME 0
-#    define GREENLET_PY310 0
 #endif
-
 
 
 #if PY_VERSION_HEX >= 0x30B00A4
@@ -122,6 +127,10 @@ static inline void PyThreadState_LeaveTracing(PyThreadState *tstate)
     tstate->use_tracing = use_tracing;
 #endif
 }
+#endif
+
+#if !defined(Py_C_RECURSION_LIMIT) && defined(C_RECURSION_LIMIT)
+#  define Py_C_RECURSION_LIMIT C_RECURSION_LIMIT
 #endif
 
 #endif /* GREENLET_CPYTHON_COMPAT_H */

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -23,6 +23,7 @@ using greenlet::refs::BorrowedGreenlet;
 #endif
 
 #if GREENLET_PY312
+#  define Py_BUILD_CORE
 #  include "internal/pycore_frame.h"
 #endif
 

--- a/src/greenlet/greenlet_greenlet.hpp
+++ b/src/greenlet/greenlet_greenlet.hpp
@@ -111,7 +111,11 @@ namespace greenlet
 #else
         int recursion_depth;
 #endif
+#if GREENLET_PY313
+        PyObject *delete_later;
+#else
         int trash_delete_nesting;
+#endif
 #if GREENLET_PY311
         _PyInterpreterFrame* current_frame;
         _PyStackChunk* datastack_chunk;

--- a/src/greenlet/tests/__init__.py
+++ b/src/greenlet/tests/__init__.py
@@ -207,7 +207,6 @@ class TestCase(TestCaseMetaClass(
 
     def run_script(self, script_name, show_output=True):
         import subprocess
-        import os
         script = os.path.join(
             os.path.dirname(__file__),
             script_name,

--- a/src/greenlet/tests/__init__.py
+++ b/src/greenlet/tests/__init__.py
@@ -3,10 +3,7 @@
 Tests for greenlet.
 
 """
-from __future__ import absolute_import
-from __future__ import division
-from __future__ import print_function
-
+import os
 import sys
 import unittest
 
@@ -27,7 +24,14 @@ from greenlet._greenlet import get_total_main_greenlets
 from . import leakcheck
 
 PY312 = sys.version_info[:2] >= (3, 12)
+PY313 = sys.version_info[:2] >= (3, 13)
+
 WIN = sys.platform.startswith("win")
+RUNNING_ON_GITHUB_ACTIONS = os.environ.get('GITHUB_ACTIONS')
+RUNNING_ON_TRAVIS = os.environ.get('TRAVIS') or RUNNING_ON_GITHUB_ACTIONS
+RUNNING_ON_APPVEYOR = os.environ.get('APPVEYOR')
+RUNNING_ON_CI = RUNNING_ON_TRAVIS or RUNNING_ON_APPVEYOR
+RUNNING_ON_MANYLINUX = os.environ.get('GREENLET_MANYLINUX')
 
 class TestCaseMetaClass(type):
     # wrap each test method with

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -220,6 +220,13 @@ class TestGreenlet(TestCase):
         self.assertIn("SomeError", v)
 
 
+    @unittest.skipIf(
+        PY313 and RUNNING_ON_MANYLINUX,
+        "Sometimes flaky (getting one GreenletExit in the second list)"
+        # Probably due to funky timing interactions?
+        # TODO: FIXME Make that work.
+    )
+
     def test_dealloc_other_thread(self):
         seen = []
         someref = []

--- a/src/greenlet/tests/test_greenlet.py
+++ b/src/greenlet/tests/test_greenlet.py
@@ -471,7 +471,9 @@ class TestGreenlet(TestCase):
         # Unfortunately, this doesn't actually clear the references, they're in the
         # fast local array.
         if not wait_for_cleanup:
-            result[0].gr_frame.f_locals.clear()
+            # f_locals has no clear method in Python 3.13
+            if hasattr(result[0].gr_frame.f_locals, 'clear'):
+                result[0].gr_frame.f_locals.clear()
         else:
             self.assertIsNone(result[0].gr_frame)
 

--- a/src/greenlet/tests/test_greenlet_trash.py
+++ b/src/greenlet/tests/test_greenlet_trash.py
@@ -34,7 +34,8 @@ class TestTrashCanReEnter(unittest.TestCase):
 
     def test_it(self):
         try:
-            from greenlet._greenlet import get_tstate_trash_delete_nesting
+            # pylint:disable-next=no-name-in-module
+            from greenlet._greenlet import get_tstate_trash_delete_nesting 
         except ImportError:
             import sys
             # Python 3.13 has not "trash delete nesting" anymore (but "delete later")
@@ -47,7 +48,7 @@ class TestTrashCanReEnter(unittest.TestCase):
 
     def check_it(self): # pylint:disable=too-many-statements
         import greenlet
-
+        from greenlet._greenlet import get_tstate_trash_delete_nesting # pylint:disable=no-name-in-module
         main = greenlet.getcurrent()
 
         assert get_tstate_trash_delete_nesting() == 0

--- a/src/greenlet/tests/test_greenlet_trash.py
+++ b/src/greenlet/tests/test_greenlet_trash.py
@@ -29,18 +29,17 @@ from __future__ import print_function, absolute_import, division
 
 import unittest
 
-try:
-    from greenlet._greenlet import get_tstate_trash_delete_nesting
-except ImportError:
-    get_tstate_trash_delete_nesting = None
-
 
 class TestTrashCanReEnter(unittest.TestCase):
 
-    # Python 3.13 has not "trash delete nesting" anymore (but "delete later")
-    @unittest.skipIf(get_tstate_trash_delete_nesting is None,
-                     'need get_tstate_trash_delete_nesting()')
     def test_it(self):
+        try:
+            from greenlet._greenlet import get_tstate_trash_delete_nesting
+        except ImportError:
+            import sys
+            # Python 3.13 has not "trash delete nesting" anymore (but "delete later")
+            assert sys.version_info[:2] >= (3, 13)
+            self.skipTest("get_tstate_trash_delete_nesting is not available.")
         # Try several times to trigger it, because it isn't 100%
         # reliable.
         for _ in range(10):
@@ -48,7 +47,6 @@ class TestTrashCanReEnter(unittest.TestCase):
 
     def check_it(self): # pylint:disable=too-many-statements
         import greenlet
-        from greenlet._greenlet import get_tstate_trash_delete_nesting # pylint:disable=no-name-in-module
 
         main = greenlet.getcurrent()
 

--- a/src/greenlet/tests/test_greenlet_trash.py
+++ b/src/greenlet/tests/test_greenlet_trash.py
@@ -35,12 +35,13 @@ class TestTrashCanReEnter(unittest.TestCase):
     def test_it(self):
         try:
             # pylint:disable-next=no-name-in-module
-            from greenlet._greenlet import get_tstate_trash_delete_nesting 
+            from greenlet._greenlet import get_tstate_trash_delete_nesting # pylint:disable=unused-import
         except ImportError:
             import sys
             # Python 3.13 has not "trash delete nesting" anymore (but "delete later")
             assert sys.version_info[:2] >= (3, 13)
             self.skipTest("get_tstate_trash_delete_nesting is not available.")
+
         # Try several times to trigger it, because it isn't 100%
         # reliable.
         for _ in range(10):

--- a/src/greenlet/tests/test_greenlet_trash.py
+++ b/src/greenlet/tests/test_greenlet_trash.py
@@ -29,8 +29,17 @@ from __future__ import print_function, absolute_import, division
 
 import unittest
 
+try:
+    from greenlet._greenlet import get_tstate_trash_delete_nesting
+except ImportError:
+    get_tstate_trash_delete_nesting = None
+
+
 class TestTrashCanReEnter(unittest.TestCase):
 
+    # Python 3.13 has not "trash delete nesting" anymore (but "delete later")
+    @unittest.skipIf(get_tstate_trash_delete_nesting is None,
+                     'need get_tstate_trash_delete_nesting()')
     def test_it(self):
         # Try several times to trigger it, because it isn't 100%
         # reliable.


### PR DESCRIPTION
Calling `PyEval_AddPendingCall` while the interpreter is finalizing can lead to a segfault due to the implementation in CPython of `PyEval_AddPendingCall`. This is a somewhat hacky fix to just check if it's finalizing before we try and schedule the cleanup.

I say _somewhat_ hacky, cause it's still possible to race between checking and actually calling `PyEval_AddPendingCall` and end up segfaulting, but in practice so far this fix has completely solved our segfaulting issues. Arguably the most ideal fix here would be to fix this call in CPython to not segfault when the interpreter is shutting down, and just terminate the thread like it now does with the locking API

Fixes #411