### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11", "3.12"]
         os: [ubuntu-latest, macos-latest]
+        exclude:
+        - python-version: 3.7
+          os: macos-latest
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -181,7 +181,7 @@ Known Issues
 =====================
 
 - Linux: Fix another group of rare crashes that could occur when shutting down an
-  interpeter running multiple threads. See `issue 325 <https://github.com/python-greenlet/greenlet/issues/325>`_.
+  interpreter running multiple threads. See `issue 325 <https://github.com/python-greenlet/greenlet/issues/325>`_.
 
 
 2.0.0rc4 (2022-10-30)

--- a/src/greenlet/TThreadStateDestroy.cpp
+++ b/src/greenlet/TThreadStateDestroy.cpp
@@ -122,7 +122,7 @@ struct ThreadState_DestroyNoGIL
 
         // NOTE: Because we're not holding the GIL here, some other
         // Python thread could run and call ``os.fork()``, which would
-        // be bad if that happenend while we are holding the cleanup
+        // be bad if that happened while we are holding the cleanup
         // lock (it wouldn't function in the child process).
         // Make a best effort to try to keep the duration we hold the
         // lock short.

--- a/src/greenlet/greenlet.cpp
+++ b/src/greenlet/greenlet.cpp
@@ -1220,7 +1220,7 @@ mod_gettrace(PyObject* UNUSED(module))
 PyDoc_STRVAR(mod_set_thread_local_doc,
              "set_thread_local(key, value) -> None\n"
              "\n"
-             "Set a value in the current thread-local dictionary. Debbuging only.\n");
+             "Set a value in the current thread-local dictionary. Debugging only.\n");
 
 static PyObject*
 mod_set_thread_local(PyObject* UNUSED(module), PyObject* args)


### PR DESCRIPTION
* https://pypi.org/project/codespell
* https://github.com/codespell-project/codespell

% `codespell --ignore-words-list=assertin,crasher,ehr,fallin,fo,minggw,re-use,seh,ths,windowz`
```
./CHANGES.rst:184: interpeter ==> interpreter
./src/greenlet/TThreadStateDestroy.cpp:125: happenend ==> happened
./src/greenlet/greenlet.cpp:1223: Debbuging ==> Debugging
```
% `codespell --ignore-words-list=assertin,crasher,ehr,fallin,fo,minggw,re-use,seh,ths,windowz --write-changes`

~Also, Python 3.7 was already end-of-life when Apple Silicon was released so Python 3.7 is not supported on modern Macs.~