### PR TITLE
Unbreak PowerPC build on macOS

### DIFF
--- a/src/greenlet/platform/switch_ppc_macosx.h
+++ b/src/greenlet/platform/switch_ppc_macosx.h
@@ -49,7 +49,7 @@ slp_switch(void)
     int err;
     int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
-    __asm__ ("; asm block 2\n\tmr %0, r1" : "=g" (stackref) : );
+    __asm__ ("; asm block 2\n\tmr %0, r1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
         __asm__ volatile (
@@ -58,7 +58,7 @@ slp_switch(void)
             "\tadd r1, r1, r11\n"
             "\tadd r30, r30, r11\n"
             : /* no outputs */
-            : "g" (stsizediff)
+            : "r" (stsizediff)
             : "r11"
             );
         SLP_RESTORE_STATE();

--- a/src/greenlet/platform/switch_ppc_unix.h
+++ b/src/greenlet/platform/switch_ppc_unix.h
@@ -50,7 +50,7 @@ slp_switch(void)
     int err;
     int *stackref, stsizediff;
     __asm__ volatile ("" : : : REGS_TO_SAVE);
-    __asm__ ("mr %0, 1" : "=g" (stackref) : );
+    __asm__ ("mr %0, 1" : "=r" (stackref) : );
     {
         SLP_SAVE_STATE(stackref, stsizediff);
         __asm__ volatile (
@@ -58,7 +58,7 @@ slp_switch(void)
             "add 1, 1, 11\n"
             "add 30, 30, 11\n"
             : /* no outputs */
-            : "g" (stsizediff)
+            : "r" (stsizediff)
             : "11"
             );
         SLP_RESTORE_STATE();

--- a/src/greenlet/slp_platformselect.h
+++ b/src/greenlet/slp_platformselect.h
@@ -21,7 +21,7 @@ extern "C" {
 # include "platform/switch_ppc64_linux.h" /* gcc on PowerPC 64-bit */
 #elif defined(__GNUC__) && defined(__PPC__) && (defined(__linux__) || defined(__FreeBSD__))
 # include "platform/switch_ppc_linux.h" /* gcc on PowerPC */
-#elif defined(__GNUC__) && defined(__ppc__) && defined(__APPLE__)
+#elif defined(__GNUC__) && defined(__POWERPC__) && defined(__APPLE__)
 # include "platform/switch_ppc_macosx.h" /* Apple MacOS X on PowerPC */
 #elif defined(__GNUC__) && defined(__powerpc64__) && defined(_AIX)
 # include "platform/switch_ppc64_aix.h" /* gcc on AIX/PowerPC 64-bit */


### PR DESCRIPTION
Current code is broken, see #418 

Looks like this is a silly copy-paste error – compare macOS file (which was likely made blindly) vs Linux one (which hopefully was actually tested).

Also, fix PowerPC macro for Darwin, so that a meaningful implementation is picked when building for `ppc64` too. I cannot test it now, but given that Darwin does not use TOC and insns in the header are supported both in 32- and 64-bit ABI, it should work fine.