### PR TITLE
Add Python 3.13 to Trove classifiers and tox

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -241,6 +241,7 @@ setup(
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py37,py38,py39,py310,py27-ns,py310-ns,py311,py311-ns,docs
+    py{37,38,39,310,311,312,313},py{310,311,312,313}-ns,docs
 
 [testenv]
 commands =


### PR DESCRIPTION
Follow on from https://github.com/python-greenlet/greenlet/pull/396.