### PR TITLE
Add missing test dependency on `setuptools`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,6 +260,7 @@ setup(
         'test': [
             'objgraph',
             'psutil',
+            'setuptools',
         ],
     },
     python_requires=">=3.9",


### PR DESCRIPTION
Add the missing test dependency on `setuptools`, as it is required by `greenlet.tests.test_version.VersionTests.test_version`.  The test is calling `setup.py` which requires `setuptools` to be installed. Prior to this change, a `tox` run on Python 3.12 or newer would fail, as these versions no longer include `setuptools` in a pristine venv:

```pytb
test_version (greenlet.tests.test_version.VersionTests.test_version) ... Traceback (most recent call last):
  File "/tmp/greenlet/setup.py", line 10, in <module>
    from setuptools import setup
ModuleNotFoundError: No module named 'setuptools'
FAIL
```