### PR TITLE
Redefine `_Py_DEC_REFTOTAL` as a private macro to fix py3.14 build

### DIFF
--- a/src/greenlet/PyGreenlet.cpp
+++ b/src/greenlet/PyGreenlet.cpp
@@ -249,7 +249,7 @@ _green_dealloc_kill_started_non_main_greenlet(BorrowedGreenlet self)
 
         PyObject_GC_Track((PyObject*)self);
 
-        _Py_DEC_REFTOTAL;
+        GREENLET_Py_DEC_REFTOTAL;
 #ifdef COUNT_ALLOCS
         --Py_TYPE(self)->tp_frees;
         --Py_TYPE(self)->tp_allocs;

--- a/src/greenlet/greenlet_cpython_compat.hpp
+++ b/src/greenlet/greenlet_cpython_compat.hpp
@@ -73,7 +73,9 @@ https://bugs.python.org/issue39573 */
 #    define Py_SET_REFCNT(obj, refcnt) Py_REFCNT(obj) = (refcnt)
 #endif
 
-#ifndef _Py_DEC_REFTOTAL
+#ifdef _Py_DEC_REFTOTAL
+#  define GREENLET_Py_DEC_REFTOTAL _Py_DEC_REFTOTAL
+#else
 /* _Py_DEC_REFTOTAL macro has been removed from Python 3.9 by:
   https://github.com/python/cpython/commit/49932fec62c616ec88da52642339d83ae719e924
 
@@ -81,12 +83,12 @@ https://bugs.python.org/issue39573 */
 */
 #    ifdef Py_REF_DEBUG
 #      if GREENLET_PY312
-#         define _Py_DEC_REFTOTAL
+#         define GREENLET_Py_DEC_REFTOTAL
 #      else
-#        define _Py_DEC_REFTOTAL _Py_RefTotal--
+#        define GREENLET_Py_DEC_REFTOTAL _Py_RefTotal--
 #      endif
 #    else
-#        define _Py_DEC_REFTOTAL
+#        define GREENLET_Py_DEC_REFTOTAL
 #    endif
 #endif
 // Define these flags like Cython does if we're on an old version.


### PR DESCRIPTION
Redefine `_Py_DEC_REFTOTAL` as a private `GREENLET_Py_DEC_REFTOTAL` macro rather than under the original name, to fix conflicts with CPython's private macro that cause the build to fail with Python 3.14.

Fixes #458