### PR TITLE
Move most of setuptools attributes to pyproject.toml

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -166,7 +166,6 @@ disable=wrong-import-position,
 enable=consider-using-augmented-assign
 
 [FORMAT]
-# duplicated from setup.cfg
 max-line-length=160
 max-module-lines=1100
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 3.3.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Make sure that the `License-Expression` attribute is correctly set
+  in the metadata.
 
 
 3.3.0 (2025-12-04)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,70 @@
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
-     "setuptools >= 40.8.0"
+     "setuptools >= 77.0.3"
 ]
+
+[project]
+name = "greenlet"
+description = "Lightweight in-process concurrent programming"
+readme = "README.rst"
+authors = [
+    { name = "Alexey Borzenkov", email = "snaury@gmail.com" },
+]
+maintainers = [
+    { name = "Jason Madden", email = "jason@seecoresoftware.com" }
+]
+license = "MIT AND Python-2.0"
+license-files = [
+    'LICENSE',
+    'LICENSE.PSF',
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "Programming Language :: C",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = [
+    "greenlet",
+    "coroutine",
+    "concurrency",
+    "threads",
+    "cooperative",
+]
+requires-python = ">=3.10"
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://greenlet.readthedocs.io"
+Documentation = "https://greenlet.readthedocs.io"
+Repository = "https://github.com/python-greenlet/greenlet"
+Issues = "https://github.com/python-greenlet/greenlet/issues"
+Changelog = "https://greenlet.readthedocs.io/en/latest/changes.html"
+
+[project.optional-dependencies]
+docs = [
+    "Sphinx",
+    "furo",
+]
+test = [
+    "objgraph",
+    "psutil",
+    "setuptools",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "greenlet.__version__"}
+
+[tools.zest-releaser]
+python-file-with-version = "src/greenlet/__init__.py"
+create-wheel = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[zest.releaser]
-python-file-with-version = src/greenlet/__init__.py
-create-wheel = no

--- a/setup.py
+++ b/setup.py
@@ -114,10 +114,6 @@ elif is_win and "MSC" in plat_compiler:
     # this:
     cpp_compile_args.append('/std:c++20')
 
-def readfile(filename):
-    with open(filename, 'r') as f: # pylint:disable=unspecified-encoding
-        return f.read()
-
 GREENLET_SRC_DIR = 'src/greenlet/'
 GREENLET_HEADER_DIR = GREENLET_SRC_DIR
 GREENLET_HEADER = GREENLET_HEADER_DIR + 'greenlet.h'
@@ -197,72 +193,9 @@ else:
     ]
 
 
-def get_greenlet_version():
-    with open('src/greenlet/__init__.py') as f: # pylint:disable=unspecified-encoding
-        looking_for = '__version__ = \''
-        for line in f:
-            if line.startswith(looking_for):
-                version = line[len(looking_for):-2]
-                return version
-    raise ValueError("Unable to find version")
-
-
 setup(
-    name="greenlet",
-    version=get_greenlet_version(),
-    description='Lightweight in-process concurrent programming',
-    long_description=readfile("README.rst"),
-    long_description_content_type="text/x-rst",
-    url="https://greenlet.readthedocs.io/",
-    keywords="greenlet coroutine concurrency threads cooperative",
-    author="Alexey Borzenkov",
-    author_email="snaury@gmail.com",
-    maintainer='Jason Madden',
-    maintainer_email='jason@seecoresoftware.com',
-    project_urls={
-        'Bug Tracker': 'https://github.com/python-greenlet/greenlet/issues',
-        'Source Code': 'https://github.com/python-greenlet/greenlet/',
-        'Documentation': 'https://greenlet.readthedocs.io/',
-        'Changes': 'https://greenlet.readthedocs.io/en/latest/changes.html',
-    },
-    license="MIT AND Python-2.0",
-    license_files=[
-        'LICENSE',
-        'LICENSE.PSF',
-    ],
-    platforms=['any'],
     package_dir={'': 'src'},
     packages=find_packages('src'),
-    include_package_data=True,
     headers=headers,
     ext_modules=ext_modules,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'Programming Language :: C',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3 :: Only',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: 3.14',
-        'Operating System :: OS Independent',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ],
-    extras_require={
-        'docs': [
-            'Sphinx',
-            'furo',
-        ],
-        'test': [
-            'objgraph',
-            'psutil',
-            'setuptools',
-        ],
-    },
-    python_requires=">=3.10",
-    zip_safe=False,
 )


### PR DESCRIPTION
- ensures that the license metadata is correctly created
- also moved setup.cfg content into pyproject.toml
- see #466
