### PR TITLE
Restore static linking of the C++ runtime for Windows wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,12 @@ jobs:
         # expect that some people will compile it themselves with that setting.
         CPPFLAGS: "-Ofast -UNDEBUG -Wall"
         CFLAGS:   "-Ofast -UNDEBUG -Wall"
+        # On Windows this step also produces the wheels we distribute, so
+        # link the C++ runtime statically, the way the Appveyor builds did
+        # through 3.3.0. Without it, _greenlet.pyd imports MSVCP140.dll,
+        # which no Windows CPython distribution ships. setup.py ignores
+        # this everywhere else.
+        GREENLET_STATIC_RUNTIME: "1"
     - name: Install greenlet (Mac)
       if: startsWith(runner.os, 'Mac')
       run: |

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,12 @@
 3.5.5 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Link the C++ runtime statically into the Windows wheels again, as the
+  Appveyor builds did through 3.3.0. Since 3.3.1 ``_greenlet.pyd``
+  imported ``MSVCP140.dll``, which no Windows CPython distribution ships,
+  so importing greenlet failed on machines without the Visual C++
+  redistributable. See `issue 525
+  <https://github.com/python-greenlet/greenlet/issues/525>`_.
 
 
 3.5.4 (2026-07-22)


### PR DESCRIPTION
`appveyor.yml` set `GREENLET_STATIC_RUNTIME: "1"` and `setup.py` still honours it by adding `/MT`. #490 removed that file when the Windows builds moved to GHA, and the step that replaced it does not set the variable, so every Windows wheel since 3.3.1 links the C++ runtime dynamically and imports `MSVCP140.dll`. No Windows CPython distribution ships that DLL, so greenlet fails to import on machines without the Visual C++ redistributable.

Setting the variable in the step that builds the published Windows wheels restores the behaviour of 3.3.0 and earlier. `setup.py` guards it with `is_win`, so the Linux build in the same step is unaffected, and the Windows ARM wheels that #490 added keep being produced.

Fixes #525
